### PR TITLE
spec: interactive prompting for publish fields and uninterrupted Propose flow

### DIFF
--- a/opensdd/cli.md
+++ b/opensdd/cli.md
@@ -559,8 +559,13 @@ Publishes an authored spec to the registry.
 #### Behavior
 
 1. Verify `opensdd.json` exists at the project root. If not, print a message suggesting `opensdd init` first and exit with code 1.
-2. Verify `opensdd.json` has a `publish` object. If not, print an error suggesting the user add a `publish` section and exit with code 1.
-3. Read the `publish` object to get `name`, `version`, `description`, `specFormat`, `dependencies`.
+2. Read the `publish` object from `opensdd.json` (may be absent or incomplete).
+3. For each required publish field (`name`, `version`, `description`, `specFormat`), if the field is missing or empty, prompt the user interactively:
+   - `name`: "Spec name (lowercase alphanumeric and hyphens): "
+   - `version`: "Version (semver, e.g. 1.0.0): "
+   - `description`: "Description: "
+   - `specFormat`: "Spec format version (e.g. 0.1.0): "
+   Only prompt for fields that are actually missing — if the `publish` section exists with some fields populated, prompt only for the remaining ones. After collecting all required fields, write the completed `publish` object back to `opensdd.json` (preserving all other manifest fields) before continuing.
 4. Verify `<specsDir>/spec.md` exists. If not, print error and exit with code 1.
 5. Run validation on the `<specsDir>/` directory (same logic as `opensdd validate`). If validation fails with errors, print them and exit with code 1.
 6. Resolve the registry source. The registry MUST be a GitHub repository URL for publishing.
@@ -600,7 +605,7 @@ Published. Spec will be available after PR is merged.
 #### Errors
 
 - OpenSDD not initialized: print message suggesting `opensdd init` and exit with code 1.
-- No `publish` section in `opensdd.json`: print error and exit with code 1.
+- User provides empty or invalid input for a required publish field: re-prompt for the same field. If the user sends EOF (Ctrl+D) or an interrupt (Ctrl+C), exit with code 1.
 - `<specsDir>/spec.md` missing: print error and exit with code 1.
 - Spec validation fails: print validation errors and exit with code 1.
 - Version already exists in registry: print error suggesting version bump and exit with code 1.

--- a/opensdd/skills/sdd-manager.md
+++ b/opensdd/skills/sdd-manager.md
@@ -121,6 +121,8 @@ Determine affected spec section → classify type → create/append to `deviatio
 
 For submitting spec changes as a PR so that implementation happens in CI (via GitHub Actions and `claude-code-action`) rather than locally. This keeps the developer's working tree clean — spec authoring happens locally, but implementation happens in CI.
 
+The agent MUST execute all steps end-to-end without pausing for user confirmation. The Propose workflow is a single uninterrupted flow from scope resolution through PR creation — the agent MUST NOT stop to ask the user whether to proceed at any intermediate step.
+
 1. **Resolve scope.** Resolve the nearest `opensdd.json` from the current working directory. All subsequent steps operate relative to the directory containing this manifest (the **package root**). Determine the **package name** from: `opensdd.json` `name` field, falling back to `publish.name`, falling back to the package root directory name. Determine the **package path** as the relative path from the git repository root to the package root (empty string for repo-root projects).
 
 2. **Identify spec changes.** Scan the working tree for modified or new spec files within `<specsDir>/` relative to the package root (check both staged and unstaged changes, as well as untracked files). Also check for modified or new `.sdd.md` files within the package root. If no spec changes are found, inform the user and suggest they author or revise a spec first using the Revise workflow. Do NOT proceed without spec changes.


### PR DESCRIPTION
## Summary

- **cli.md `opensdd publish`**: Replace hard-fail behavior when `publish` section is missing/incomplete with interactive prompts for each missing required field (`name`, `version`, `description`, `specFormat`). The CLI collects only what's missing, writes the completed `publish` object back to `opensdd.json`, then continues the publish flow.
- **sdd-manager Propose workflow**: Add explicit requirement that the agent MUST execute all Propose steps end-to-end without pausing for user confirmation at intermediate steps.

Merging this PR will trigger auto-implementation via GitHub Actions.

<!-- opensdd
package-name: opensdd
package-path: 
specs-dir: opensdd
-->