### PR TITLE
spec: replace implementation with implementedVersion

### DIFF
--- a/opensdd/cli.md
+++ b/opensdd/cli.md
@@ -396,7 +396,7 @@ The install mode is resolved in this order:
 4. Fetch `index.json` from `registry/<name>/` in the configured registry source. If `[version]` is provided, use that version; otherwise use `latest` from `index.json`.
 5. Read `manifest.json` from `registry/<name>/<version>/` to get specFormat and dependencies.
 6. Copy all files from `registry/<name>/<version>/` into `<depsDir>/<name>/` (including `manifest.json`, `spec.md`, and any supplementary files).
-7. Add an entry to `opensdd.json` under `dependencies.<name>` with fields from `manifest.json` (`version`, `specFormat`), the resolved registry URL as `source`, and consumer-managed fields initialized to defaults: `implementation: null`, `tests: null`, `hasDeviations: false`.
+7. Add an entry to `opensdd.json` under `dependencies.<name>` with fields from `manifest.json` (`version`, `specFormat`), the resolved registry URL as `source`, and consumer-managed fields initialized to defaults: `implementedVersion: null`, `tests: null`, `hasDeviations: false`. If the existing entry (from a prior install of the same spec) contains a legacy `implementation` field, the CLI MUST drop it — it is not migrated into `implementedVersion` and not preserved.
 8. If the spec has `dependencies`, check whether each dependency name exists as a key in `opensdd.json`'s `dependencies` object. If any are missing, print a warning listing the missing dependencies and suggesting `opensdd install` for each.
 9. Print a success message.
 
@@ -412,7 +412,7 @@ When the resolved install mode is `"skill"`:
 4. Fetch `index.json` from `registry/<name>/` in the configured registry source. If `[version]` is provided, use that version; otherwise use `latest` from `index.json`.
 5. Fetch the `SKILL.md` from `registry/<name>/<version>/`. If no `SKILL.md` exists, generate one from `spec.md` using `generateSkillMd`. Also fetch any supplementary `.md` files (excluding `spec.md`, `manifest.json`, `deviations.md`).
 6. Install the skill files across all supported agent formats, following the same per-agent mapping used by `opensdd init` (see Skill Installation Mapping). The skill is installed under the spec's name (e.g., `.claude/skills/<name>/SKILL.md`). Supplementary `.md` files are placed in a `references/` subdirectory.
-7. Add an entry to `opensdd.json` under `dependencies.<name>` with `version`, `specFormat`, `source`, and `mode: "skill"`. Consumer-managed fields (`implementation`, `tests`, `hasDeviations`) are NOT included.
+7. Add an entry to `opensdd.json` under `dependencies.<name>` with `version`, `specFormat`, `source`, and `mode: "skill"`. Consumer-managed fields (`implementedVersion`, `tests`, `hasDeviations`) are NOT included.
 8. Print a success message.
 
 - `opensdd install slugify` in skill mode MUST install skill files across all agent formats and add a `slugify` entry to `opensdd.json` `dependencies` with `mode: "skill"`
@@ -519,7 +519,7 @@ Applies a staged update to `opensdd.json`, confirming that the migration is comp
 3. Prompt the user for confirmation (y/n). If declined, exit with code 0.
 4. For each pending update:
    a. Read `.opensdd.deps/.updates/<name>/manifest.json` to get the update metadata.
-   b. Update the `opensdd.json` `dependencies.<name>` entry: set `version`, `source`, and `specFormat` from the manifest. Preserve all consumer-managed fields (`implementation`, `tests`, `hasDeviations`).
+   b. Update the `opensdd.json` `dependencies.<name>` entry: set `version`, `source`, and `specFormat` from the manifest. Preserve all consumer-managed fields (`implementedVersion`, `tests`, `hasDeviations`) — the CLI MUST NOT modify `implementedVersion` during apply. If the entry contains a legacy `implementation` field, drop it (do not migrate, do not preserve). The divergence between `version` and `implementedVersion` after apply is the intended stale-implementation signal when the user ran `update apply` without first bringing the implementation into conformance.
    c. Delete the `.opensdd.deps/.updates/<name>/` directory.
 5. If `.opensdd.deps/.updates/` is now empty, delete it.
 6. Print a summary.
@@ -647,10 +647,12 @@ Authored spec:
 
 Installed dependencies:
 
-  slugify     v2.1.0  implemented       src/utils/slugify.ts
-  payments    v1.3.0  implemented       src/payments/index.ts    2 deviations
+  slugify     v2.1.0  implemented v2.1.0
+  payments    v1.4.0  stale (impl v1.3.0)                        2 deviations
   http-retry  v1.0.0  not implemented
 ```
+
+The status column for each dependency MUST be derived as: `not implemented` if `implementedVersion` is null; `implemented <implementedVersion>` if `implementedVersion === version`; `stale (impl <implementedVersion>)` if `implementedVersion !== version`.
 
 #### Errors
 
@@ -876,11 +878,13 @@ For local paths, the CLI MUST read directly from the filesystem. This supports d
 ### Consumer-Managed Field Preservation
 
 During `opensdd update apply`, the CLI MUST preserve these `opensdd.json` fields for each affected dependency entry:
-- `implementation`
+- `implementedVersion`
 - `tests`
 - `hasDeviations`
 
-The CLI reads the existing `opensdd.json` dependency entry, applies updated metadata from the staged manifest, then re-applies the consumer-managed field values. Note that `opensdd update` does NOT touch `opensdd.json` at all — it only stages the update. The `opensdd.json` entry continues to reflect the old version until `opensdd update apply` is called.
+The CLI reads the existing `opensdd.json` dependency entry, applies updated metadata from the staged manifest, then re-applies the consumer-managed field values. Note that `opensdd update` does NOT touch `opensdd.json` at all — it only stages the update. The `opensdd.json` entry continues to reflect the old version until `opensdd update apply` is called. Preserving `implementedVersion` across `update apply` is intentional: if the user ran `update apply` without bringing the implementation into conformance, the manifest will show `version !== implementedVersion` as a stale-implementation signal. The agent's Update workflow (see sdd-manager) is responsible for setting `implementedVersion` to the new version once conformance work is complete.
+
+Legacy `implementation` field: if present in an existing `opensdd.json` dependency entry, the CLI MUST ignore it — do not read it, do not preserve it across update apply, do not migrate its value into `implementedVersion`, and do not warn. The first write operation that touches the entry MUST drop the legacy field from the persisted manifest.
 
 ## Edge Cases
 

--- a/opensdd/skills/sdd-manager.md
+++ b/opensdd/skills/sdd-manager.md
@@ -96,7 +96,7 @@ For first-time implementation of a dependency spec.
 
 5. **Verify:** Execute the full verification protocol (see Verification Protocol section below): generate test suite → run tests until all pass (or SHOULD bail after 50 attempts) → dispatch subagent for spec compliance audit → fix any findings → re-run tests.
 
-6. **Record:** Update `opensdd.json` `dependencies` entry with `implementation` path, `tests` path, and `hasDeviations` if applicable.
+6. **Record:** Update the `opensdd.json` `dependencies.<name>` entry: set `implementedVersion` to the installed spec's `version`, set `tests` to the generated test file path, and set `hasDeviations` to `true` if a deviation was created during step 2. The agent MUST set `implementedVersion` only after verification in step 5 has succeeded.
 
 7. **Report:** Report results with spec coverage summary.
 
@@ -107,7 +107,8 @@ For first-time implementation of a dependency spec.
 3. Present the changes to the user: summarize what changed, flag stale deviations, and ask whether the user wants to adjust any deviations before proceeding.
 4. Patch implementation to conform to the new behavioral contract.
 5. Regenerate affected tests → run until all pass → dispatch subagent for spec compliance audit scoped to the changed sections → fix any findings → re-run tests.
-6. Tell the user to run `opensdd update apply <name>` to finalize the update in `opensdd.json`. The agent MUST always specify the spec name explicitly — it MUST NOT suggest or use the no-args batch form (`opensdd update apply` without a name).
+6. Tell the user to run `opensdd update apply <name>` to finalize the version bump in `opensdd.json`. The agent MUST always specify the spec name explicitly — it MUST NOT suggest or use the no-args batch form (`opensdd update apply` without a name).
+7. After the user confirms that `opensdd update apply <name>` has been run, the agent MUST update the `dependencies.<name>.implementedVersion` field in `opensdd.json` to match the new `version` the CLI just applied. This attests that the implementation has been brought into conformance with the new spec version. If the user skips the apply step, the agent MUST NOT set `implementedVersion` — leaving `version` and `implementedVersion` out of sync is the correct signal that the migration is incomplete.
 
 ### Check Conformance
 

--- a/opensdd/spec-format.md
+++ b/opensdd/spec-format.md
@@ -310,7 +310,7 @@ The `opensdd.json` file is the project-level manifest. It lives at the project r
       "version": "2.1.0",
       "source": "https://github.com/deepagents-ai/opensdd",
       "specFormat": "0.1.0",
-      "implementation": null,
+      "implementedVersion": null,
       "tests": null,
       "hasDeviations": false
     }
@@ -353,7 +353,7 @@ The root manifest allows repo-level commands (e.g., `opensdd setup-ci`) to detec
 - `version` (required): Semver version of the installed spec.
 - `source` (required): URL of the registry this spec was installed from.
 - `specFormat` (required): OpenSDD protocol version of the installed spec.
-- `implementation` (consumer-managed): Path to the generated implementation file, `null` until implemented.
+- `implementedVersion` (consumer-managed): Semver string recording the spec version the implementation was last brought into conformance with. `null` until the spec has been implemented. When `implementedVersion` differs from `version`, the implementation is considered stale relative to the installed spec.
 - `tests` (consumer-managed): Path to the generated test file, `null` until implemented.
 - `hasDeviations` (consumer-managed): Boolean, `false` until a deviation is created.
 
@@ -551,6 +551,7 @@ Specs use semantic versioning:
 - Only the H1 header, blockquote summary, and `## Behavioral Contract` are required. All other sections (Edge Cases, NOT Specified, Invariants, Options / Configuration, Implementation Hints) are recommended but optional.
 - A spec dependency that is not installed: the implementing agent MUST warn the user but MAY proceed if the dependent types can be inferred from context.
 - `deviations.md` referencing a spec section removed in an update: the agent SHOULD flag the deviation as potentially stale during the Update workflow.
+- Legacy `implementation` field in `opensdd.json` dependency entries (from pre-`implementedVersion` manifests): tooling MUST ignore the field — it MUST NOT be read, written, migrated, or warned about. Consumers with legacy manifests get `implementedVersion: null` treatment on the next operation that touches the entry.
 - Extra fields in a dependency's `opensdd.json` entry beyond those defined by this format: extra fields MUST be preserved during updates and MUST NOT cause errors.
 - Circular spec dependencies (A depends on B, B depends on A): not currently supported. The implementing agent MUST detect and report the cycle rather than recursing infinitely.
 - `opensdd.json` dependency entry exists but spec directory is missing in `.opensdd.deps/`: the CLI MUST warn and offer to re-install from registry.


### PR DESCRIPTION
## Summary

Redefine the consumer-managed `implementation` field on dependency entries in `opensdd.json` as **`implementedVersion`** — a semver string recording the spec version the implementation was last brought into conformance with. When `implementedVersion !== version`, the manifest mechanically indicates the implementation is stale relative to the installed spec.

## Rationale

The existing `implementation` field stores a path to the generated implementation file. It's a useful pointer but a poor signal for the most interesting case: when a spec is updated from v1 to v2 but the code has not yet been brought into conformance with v2. The manifest shows the path unchanged and provides no mechanical way to flag the impl as stale.

Tracking the *version* the implementation was last conformed against makes this obvious: `status` can render `implemented v1.0.0` vs `stale (impl v1.0.0)` by comparing two fields already in the manifest.

The old `implementation` field is deprecated and removed from the protocol with no backwards-compat handling. If a legacy `implementation` key exists in an existing `opensdd.json`, tooling ignores it (does not read, preserve, migrate, or warn). Consumers with legacy manifests get `implementedVersion: null` treatment on next touch.

## Changes

- **`opensdd/spec-format.md`** — Rename field in example JSON and field definition. Add edge-case note documenting that legacy `implementation` values MUST be ignored.
- **`opensdd/cli.md`** — Update `install` to initialize `implementedVersion: null` and drop any legacy `implementation` field. Update `update apply` to preserve (not set) `implementedVersion`; the preserved-old-version-after-version-bump is the intended stale signal. Update `status` output and derivation rules. Update the Consumer-Managed Field Preservation list.
- **`opensdd/skills/sdd-manager.md`** — Implement workflow's Record step now sets `implementedVersion` to the installed `version` after verification succeeds. Update workflow gains a step 7 that sets `implementedVersion` to the new version after the user runs `update apply`, with explicit guidance to leave it out of sync if the user skips the apply step.

## Workflow impact

- **Install flow:** `install` → `implementedVersion: null` → agent implements → agent sets `implementedVersion = version`. Status shows `implemented <version>`.
- **Update flow:** `opensdd update` stages changes (manifest untouched) → agent conforms code to new spec → user runs `opensdd update apply` (bumps `version`, preserves `implementedVersion`) → agent sets `implementedVersion` to the new version. If the user skips the apply or the agent step, the resulting `version !== implementedVersion` state is the correct stale signal.

## CI

Merging this PR will automatically create an implementation issue. `claude-code-action` will pick up the issue and open an implementation PR scoped to the changes above.

<!-- opensdd
package-name: opensdd
package-path: ""
specs-dir: opensdd
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)