### PR TITLE
Add agent-backend v0.9.5

### DIFF
--- a/registry/agent-backend/0.9.5/SKILL.md
+++ b/registry/agent-backend/0.9.5/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: agent-backend
+description: "Client library and server daemon providing a unified API for agent-filesystem interaction within local or remote sandboxed workspaces."
+---
+# agent-backend
+
+> Client library and server daemon providing a unified API for agent-filesystem interaction within local or remote sandboxed workspaces.
+
+## Overview
+
+Agent Backend is composed of three independently spec'd components. Each component spec is self-contained and defines a complete behavioral contract using [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) requirement keywords.
+
+- **[Client Libraries](clients.md)** -- Behavioral contract for all client implementations (TypeScript, Python, etc.). Covers backend types, connection lifecycle, file operations, command execution, scoping, MCP integration, connection pooling, error handling, operations logging, and adapters.
+- **[agentbe-daemon](daemon.md)** -- Behavioral contract for the server-side daemon process. Covers operating modes, configuration, HTTP/WebSocket endpoints, authentication, MCP request handling, SSH-over-WebSocket, SFTP, conventional SSH, graceful shutdown, and Docker packaging.
+- **[Command Safety](safety.md)** -- Behavioral contract for command safety validation. Covers pre-processing rules, dangerous command patterns, workspace escape patterns, and response format. Referenced by both the client and daemon specs.
+
+## Terminology
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are used as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+**Backend** -- A client-side object that provides file operations, command execution, and MCP tool access against a workspace (local directory or remote server). Implementations SHOULD define a base Backend interface that all backend types implement. Operations that only apply to file-based backends (e.g., exec) MAY be separated into a more specific interface.
+
+**Scoped Backend** -- A backend wrapper that restricts operations to a subdirectory of the parent's workspace. Scoped backends delegate operations to their parent after translating paths. Implementations SHOULD treat scoped backends as a distinct type from the backends they wrap, since they have different lifecycle semantics (e.g., destroy does not release resources, status is delegated).
+
+**Workspace** -- The root directory a backend operates within. All paths are relative to this root.
+
+**Scope** -- A restricted view of a backend, rooted at a subdirectory of the parent's workspace. Used for multi-tenant isolation.
+
+**agentbe-daemon** -- The server process that runs on a host and serves the workspace via MCP and SSH over WebSockets.
+
+## Behavioral Contract
+
+The full behavioral contract is defined across the three component specs linked above. Each component spec is self-contained and independently implementable.
+
+### Client Libraries
+
+Defines the behavioral contract for backend types (local filesystem, remote filesystem, memory), their connection lifecycle, file operations, command execution with safety validation and isolation, workspace scoping for multi-tenant isolation, MCP integration, connection pooling, error handling, operations logging, and Vercel AI SDK adapters.
+
+Implementations MUST use idiomatic patterns for their language (e.g., Python may use `async with` for lifecycle, TypeScript may use `await destroy()`). The exact method names, parameter ordering, and error handling idioms are left to each implementation, but the semantics described in [clients.md](clients.md) MUST be preserved.
+
+See the complete [Client Libraries spec](clients.md).
+
+### agentbe-daemon
+
+Defines the behavioral contract for the daemon's two operating modes (full HTTP server and local-only stdio), CLI configuration, HTTP and WebSocket endpoints, bearer token authentication, per-request MCP handling with dynamic scoping, SSH-over-WebSocket transport with SFTP path jailing, optional conventional SSH, graceful shutdown ordering, and Docker image packaging.
+
+The exact framework or runtime (Express, Fastify, etc.) is an implementation detail left to each language. Implementations MUST conform to the semantics described in [daemon.md](daemon.md).
+
+See the complete [agentbe-daemon spec](daemon.md).
+
+### Command Safety
+
+Defines the pre-processing rules (lowercase normalization, heredoc stripping, allowlist), the complete list of dangerous command regex patterns (destructive operations, privilege escalation, pipe-to-shell, network tools, command substitution, etc.), workspace escape patterns, and the required response format when a command is blocked.
+
+Both the [Client Libraries](clients.md) and [agentbe-daemon](daemon.md) specs reference this document for command safety enforcement. See the complete [Command Safety spec](safety.md).
+
+## NOT Specified (Implementation Freedom)
+
+- Programming language for implementations (TypeScript and Python exist today; others may follow)
+- Exact method names, parameter ordering, and error handling idioms (language-idiomatic patterns are preferred)
+- Internal data structures and algorithms
+- Caching strategies
+- Logging implementation details beyond the specified log entry format
+- Test framework and test runner
+- CI/CD pipeline configuration
+- Package manager choice
+- HTTP framework for the daemon (Express, Fastify, etc.)
+
+## Invariants
+
+- All file operations MUST be confined to the workspace root directory (path jailing)
+- Scoped backends MUST NOT access paths outside their scope, even if valid within the parent workspace
+- Backend status MUST follow the defined state machine transitions and MUST NOT skip states
+- Destroying a backend MUST release all associated resources
+- MCP tool names and schemas MUST match the official MCP Filesystem Server
+- Command safety validation MUST occur before command execution when dangerous command blocking is enabled
+- All RFC 2119 keywords in component specs are binding requirements

--- a/registry/agent-backend/0.9.5/clients.md
+++ b/registry/agent-backend/0.9.5/clients.md
@@ -1,0 +1,484 @@
+# Client Libraries
+
+> Language-agnostic behavioral contract for the Agent Backend client library API.
+
+## Backend Types
+
+### Filesystem Backend (Local)
+
+Operates directly on the local filesystem using OS-level APIs. Status is always "connected" until destroyed.
+
+Configuration:
+- Workspace root directory (required)
+- Isolation mode (auto, bwrap, software, none)
+- Whether to block dangerous commands (default: true)
+- Maximum output length for command execution
+- Shell preference (bash, sh, auto)
+
+### Filesystem Backend (Remote)
+
+Same operations as local, but executed on a remote host via SSH (for file ops) and MCP over HTTP (for tool calls). Requires explicit connection and supports reconnection.
+
+Configuration:
+- Workspace root directory on the remote host (required)
+- Remote host (required)
+- Transport type: SSH-over-WebSocket (default) or conventional SSH (optional to support)
+- Authentication credentials (token for WebSocket/MCP; password or key-based for conventional SSH)
+- MCP server port
+- Reconnection settings (max retries, backoff)
+- Operation timeout
+- Keepalive interval
+
+### Memory Backend
+
+In-memory key/value store. Keys act as pseudo file paths. Does NOT support command execution.
+
+Configuration:
+- Root prefix (optional, default "/")
+- Initial data to pre-populate the store
+
+---
+
+## Connection Lifecycle
+
+Backends have a status that reflects their connection state. All backend types MUST expose the same connection status API — the same status property, the same status enum, and the same `onStatusChange` subscription method — regardless of whether the backend actually has meaningful status transitions. This allows host applications to write generic code that handles any backend type without branching on backend kind. For example, a UI can bind a single status indicator to `backend.status` and `backend.onStatusChange()` and have it work identically for local, remote, and memory backends.
+
+### Status Values
+
+- **connected** -- Normal operating state.
+- **connecting** -- Initial connection in progress.
+- **disconnected** -- No active connection (remote only).
+- **reconnecting** -- Retrying after connection loss (remote only).
+- **destroyed** -- Backend has been torn down. No further operations allowed.
+
+### Behavior by Backend Type
+
+**Local filesystem:**
+- MUST start in "connected" status.
+- MUST transition to "destroyed" on destroy.
+- MUST NOT have any other status transitions.
+
+**Remote filesystem:**
+- MUST start in "disconnected" status.
+- MUST transition to "connecting" on first operation or explicit connect call.
+- MUST transition to "connected" on successful connection.
+- SHOULD attempt reconnection on connection loss if reconnection is enabled.
+- MUST transition to "reconnecting" during retry attempts.
+- MUST transition to "destroyed" on destroy.
+- MUST reject all pending operations when connection is lost.
+
+**Memory:**
+- MUST start in "connected" status.
+- MUST transition to "destroyed" on destroy.
+
+### Status Observation
+
+Implementations MUST provide a way to subscribe to status changes. Callbacks MUST fire on every status transition.
+
+### Reconnection Behavior (Remote Backends)
+
+Remote backends maintain two independent channels to the daemon: an SSH channel (for file operations and exec) and an MCP channel (HTTP, for tool calls). These channels have different failure and retry semantics.
+
+#### SSH Channel
+
+The SSH channel (SSH-over-WebSocket or conventional SSH) is a persistent connection. Implementations MUST detect connection loss via transport-level events (WebSocket `close`, SSH `close`) and keepalive failures.
+
+**Keepalive:** Implementations SHOULD send SSH keepalive probes at a configurable interval (default: 30 seconds). After a configurable number of missed responses (default: 3), the connection MUST be considered dead and closed.
+
+**On disconnection:**
+1. MUST immediately reject all pending operations with a connection-closed error.
+2. MUST clear any cached transport state (e.g., SFTP sessions).
+3. MUST transition status to "disconnected".
+4. MUST schedule a reconnection attempt if reconnection is enabled.
+
+**Reconnection:** Implementations MUST support automatic reconnection with exponential backoff. The reconnection configuration MUST include:
+- Whether reconnection is enabled (default: true)
+- Maximum retry count (default: 5; 0 means unlimited)
+- Initial delay (default: 1000ms)
+- Maximum delay cap (default: 30000ms)
+- Backoff multiplier (default: 2)
+
+The delay sequence follows `min(initialDelay * multiplier^attempt, maxDelay)`. On successful reconnection, the retry counter MUST reset to zero and status MUST transition to "connected". If max retries are exhausted, the backend MUST remain in "disconnected" status and stop retrying.
+
+If `destroy()` is called while a reconnection is pending, the scheduled retry MUST be cancelled.
+
+#### MCP Channel (HTTP)
+
+The MCP channel uses stateless HTTP requests. There is no persistent connection and no daemon-side session state. Each tool call is an independent HTTP request to the daemon's MCP endpoint.
+
+If an MCP request fails (network error, timeout, non-2xx response), the error MUST propagate to the caller. Implementations MUST NOT automatically retry MCP requests — the caller (typically the AI SDK or application layer) is responsible for retry decisions.
+
+#### Daemon-Side Connection Handling
+
+The daemon does not maintain long-lived client sessions. Each channel is independent:
+
+**SSH-over-WebSocket:** Each incoming WebSocket connection gets its own ephemeral SSH server instance. When the WebSocket closes, the SSH server for that connection is torn down. Spawned child processes (from exec) are not explicitly killed — they terminate naturally when their I/O pipes break.
+
+**MCP over HTTP:** Each HTTP request is handled independently with no server-side session state. There is nothing to clean up when a client disappears.
+
+This stateless daemon design means the client is always responsible for reconnection. The daemon does not track clients, send heartbeats, or attempt to notify clients of impending disconnection. If the daemon process itself restarts, all WebSocket connections drop and clients detect this through their normal disconnection handling.
+
+---
+
+## Destroy / Resource Cleanup
+
+Every backend MUST provide a destroy operation that tears down all resources.
+
+### Behavior
+
+- MUST close all MCP clients and transports created via the backend's MCP integration methods.
+- MUST close all resources registered via the closeable tracking mechanism (see below).
+- MUST set status to "destroyed".
+- SHOULD be idempotent (calling destroy twice MUST NOT throw).
+- For remote backends: MUST cancel any pending reconnection attempts, reject all pending operations, and close SSH/WebSocket connections.
+- MUST NOT destroy child scoped backends automatically. Children become orphaned when the parent is destroyed.
+
+### Closeable Tracking
+
+Backends MUST provide a way to register external closeable resources (objects with a close method). These resources MUST be closed when the backend is destroyed. This is used internally for MCP clients and transports, and MAY be used by consumers for their own resources.
+
+---
+
+## File Operations
+
+All file-based backends (local, remote, and memory) MUST support the following operations. Paths are always relative to the backend's workspace root unless otherwise noted.
+
+### Path Resolution
+
+Path handling follows the three-case resolution logic and escape prevention rules defined in [docs/filepaths.md](../docs/filepaths.md), which is the source of truth for path behavior. In summary:
+
+- Relative paths MUST be resolved against the workspace root.
+- Absolute paths that match the workspace root MUST be used directly.
+- Absolute paths that do NOT match the workspace root MUST be treated as relative (leading slash stripped).
+- Paths containing `..` that would escape the workspace MUST be rejected with a path escape error.
+- These rules apply at every scope level for scoped backends.
+
+See [docs/filepaths.md](../docs/filepaths.md) for detailed examples, backend-specific path module conventions, and scoped workspace behavior.
+
+### read(path)
+
+Read the contents of a file.
+
+- MUST return file contents as text (default) or raw bytes.
+- MUST throw if the file does not exist.
+- Implementations SHOULD support an encoding option to choose between text and binary output.
+
+### write(path, content)
+
+Write content to a file, creating or overwriting it.
+
+- MUST accept text or binary content.
+- MUST create parent directories automatically if they do not exist.
+- MUST throw on write failure.
+
+### readdir(path)
+
+List the immediate children of a directory.
+
+- MUST return a list of entry names (not full paths).
+- For memory backends: MUST simulate directory listing via prefix matching on keys, returning only immediate children (first path segment after the prefix).
+
+### mkdir(path)
+
+Create a directory.
+
+- MUST support recursive creation (create intermediate directories).
+- For memory backends: MUST be a no-op (directories are implicit in key structure).
+
+### exists(path)
+
+Check whether a file or directory exists.
+
+- MUST return a boolean.
+- MUST NOT throw if the path does not exist.
+
+### stat(path)
+
+Get metadata about a file or directory.
+
+- MUST return at minimum: whether it is a file or directory, size in bytes, and modification timestamp.
+- For memory backends: MUST return synthetic stats based on the stored value.
+
+### rm(path)
+
+Delete a file or directory.
+
+- MUST support a recursive option for deleting directories and their contents.
+- MUST support a force option that suppresses errors when the target does not exist.
+- For memory backends with recursive mode: MUST delete the exact key and all keys sharing the prefix.
+
+### rename(oldPath, newPath)
+
+Move or rename a file.
+
+- Both paths MUST be validated against the workspace boundary.
+
+### touch(path)
+
+Create an empty file if it does not exist.
+
+- MUST NOT overwrite existing files.
+- For memory backends: MUST create the key with an empty value if it does not exist.
+
+---
+
+## Command Execution
+
+### exec(command)
+
+Execute a shell command within the workspace.
+
+- MUST run the command in a shell (bash preferred, sh as fallback).
+- MUST set the working directory to the workspace root (or the scope root for scoped backends).
+- MUST set the HOME environment variable to the working directory.
+- MUST return the command's standard output as text (default) or raw bytes.
+- MUST throw if the command exits with a non-zero exit code. The error SHOULD include stderr (or stdout if stderr is empty).
+- Implementations SHOULD support an encoding option (text vs binary output).
+- Implementations SHOULD support a custom working directory option, validated to be within the workspace.
+- Implementations SHOULD support custom environment variables per invocation.
+- Memory backends MUST throw a not-implemented error.
+
+### Output Limits
+
+If a maximum output length is configured:
+- MUST truncate output that exceeds the limit.
+- SHOULD append a message indicating truncation occurred and the original output length.
+
+### Safety Validation
+
+When dangerous command blocking is enabled (default):
+- MUST check commands against known dangerous patterns before execution.
+- MUST reject dangerous commands with an appropriate error.
+- See [Command Safety](#command-safety) for the full list of blocked patterns.
+
+### Isolation
+
+Implementations SHOULD support isolation modes for sandboxing command execution:
+
+- **auto** (default) -- Detect the best available isolation method. SHOULD use bwrap if available on Linux, falling back to software validation.
+- **bwrap** (Linux) -- Namespace isolation via bubblewrap. See [bwrap details](#bwrap-sandbox) below.
+- **software** -- Heuristic-based command and path validation only. Works on all platforms.
+- **none** -- No isolation. Trust mode for controlled environments.
+
+#### bwrap Sandbox
+
+When bwrap isolation is active, commands MUST be executed inside a bubblewrap sandbox with the following configuration:
+
+**Filesystem mounts:**
+- System directories (`/usr`, `/lib`, `/lib64`, `/bin`, `/sbin`) MUST be mounted read-only.
+- The workspace root directory MUST be mounted read-write at a sandbox path (e.g., `/tmp/agentbe-workspace`).
+- `/dev`, `/proc` MUST be provided as isolated mounts.
+- `/tmp` MUST be provided as an isolated tmpfs.
+
+**Namespace isolation:**
+- All namespaces MUST be unshared (`--unshare-all`).
+- Network access MUST be preserved (`--share-net`).
+- The sandbox process MUST be killed if the parent process dies (`--die-with-parent`).
+
+**Working directory:**
+- The working directory inside the sandbox MUST correspond to the workspace root (or scope root for scoped backends), mapped to the sandbox mount path.
+- HOME MUST be set to the sandbox working directory.
+
+**Detection:**
+- When isolation mode is `auto`, implementations SHOULD check for bwrap availability (e.g., `command -v bwrap`) and fall back to `software` if not found.
+- When isolation mode is explicitly `bwrap`, implementations MUST throw an error if bwrap is not available.
+
+---
+
+## Scoping
+
+Scoping creates a restricted sub-backend rooted at a subdirectory of the parent workspace. This is the primary mechanism for multi-tenant isolation.
+
+### Creating a Scope
+
+- MUST accept a relative path within the parent workspace.
+- MUST validate that the scope path does not escape the parent workspace.
+- MAY accept custom environment variables that apply to all commands executed within the scope.
+- MAY accept an operations logger for the scope.
+
+### Scoped Backend Behavior
+
+- All file operations MUST be translated to the parent's path space by prepending the scope path.
+- exec() MUST set the working directory to the scope's root directory.
+- Environment variables MUST be merged: scope env as base, per-command env as override.
+- Path validation MUST be applied at the scope level. Paths that escape the scope MUST be rejected, even if they would be valid within the parent.
+- The scope's status MUST be inherited from the parent dynamically (via getter, not copied at construction time).
+- Scoped backends MUST delegate closeable tracking to the root backend.
+- On first write operation, the scope MUST ensure its root directory exists (create if needed). This MUST be deduped to prevent concurrent creation.
+
+### Nested Scoping
+
+- Scopes MUST support creating child scopes.
+- Paths combine: the child's scope path is joined with the parent scope's path.
+- Environment variables merge at each level (deeper scopes override shallower ones).
+
+### Scope Destruction
+
+- Destroying a scoped backend MUST notify the parent so it can unregister the child.
+- Destroying a scoped backend MUST NOT destroy the parent.
+- Scoped backends perform no resource cleanup themselves (that is the parent's responsibility).
+
+---
+
+## MCP Integration
+
+Backends MUST provide a way to obtain an MCP (Model Context Protocol) client or transport for exposing workspace tools to AI agents.
+
+**Important:** The MCP protocol evolves independently of this spec. Before implementing or updating MCP integration, the implementer MUST consult the latest [MCP specification](https://spec.modelcontextprotocol.io/) and [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) for current transport types, client APIs, and protocol details. The behavioral requirements below describe the integration semantics; the exact MCP client/transport APIs may change across MCP SDK versions.
+
+### MCP Transport
+
+- MUST return a transport suitable for connecting to an MCP server that operates on the backend's workspace.
+- For local and memory backends: MUST spawn the `agent-backend daemon` CLI as a subprocess (stdio transport).
+- For remote backends: MUST create an HTTP transport pointing at the remote MCP server.
+- MAY accept a scope path to restrict the MCP server's workspace.
+- The returned transport MUST be tracked for automatic cleanup on destroy.
+
+### MCP Client
+
+- MUST return a connected MCP client wrapping the transport.
+- The client MUST be tracked for automatic cleanup on destroy.
+- For local backends: the CLI is spawned with appropriate flags (root directory, isolation mode, shell, local-only).
+- For remote backends: the client connects to the remote host's MCP server with authentication.
+
+### MCP Server Tools
+
+When a backend is served via MCP (through the agentbe-daemon), the daemon registers filesystem and execution tools. See the [MCP Server Tools](daemon.md#mcp-server-tools) section of the daemon spec for the full tool list and compatibility requirements.
+
+---
+
+## Connection Pooling
+
+A pool manager provides backend reuse for stateless servers (e.g., web servers handling many requests).
+
+### Key-Based Pooling
+
+- MUST maintain at most one backend instance per key.
+- If a backend for a given key exists and is connected, MUST reuse it.
+- If a backend for a given key does not exist or is not connected, MUST create a new one.
+- Requests without a key MUST create a fresh (non-pooled) backend each time.
+
+### Acquisition and Release
+
+- MUST support both explicit acquire/release and a callback pattern (execute a function with automatic release).
+- Acquiring MUST increment a usage counter; releasing MUST decrement it.
+- The callback pattern MUST release the backend even if the function throws.
+
+### Idle Cleanup
+
+- Backends with zero active usage that exceed the idle timeout MUST be eligible for cleanup.
+- Cleanup MUST call destroy on idle backends and remove them from the pool.
+- Periodic cleanup MAY be enabled via configuration.
+
+### Configuration Override
+
+- Per-request configuration overrides MUST be supported.
+- Overrides are merged with the pool's default configuration (override values take precedence).
+
+### Statistics
+
+- MUST expose pool stats: total backends, active (in-use) backends, idle backends.
+
+---
+
+## Error Handling
+
+Implementations MUST define error types that distinguish between the following failure modes:
+
+### Backend Error (base)
+
+General backend operation failure. MUST include:
+- An error code string identifying the failure type
+- A human-readable message
+- Optionally, the operation that failed
+
+### Dangerous Operation Error
+
+Thrown when a command is blocked by safety validation.
+- MUST include the command that was blocked.
+
+### Path Escape Error
+
+Thrown when a path resolves outside the workspace or scope boundary.
+- MUST include the offending path.
+
+### Not Implemented Error
+
+Thrown when an operation is not supported by the backend type (e.g., exec on memory backend).
+- MUST include the operation name and backend type.
+
+### Error Codes
+
+Implementations SHOULD use consistent error codes across backends:
+
+| Code | Meaning |
+|------|---------|
+| EMPTY_COMMAND | Empty command string passed to exec |
+| UNSAFE_COMMAND | Command failed safety check |
+| EXEC_FAILED | Command exited with non-zero status |
+| EXEC_ERROR | Command could not be spawned |
+| READ_FAILED | File read failed |
+| WRITE_FAILED | File write failed |
+| LS_FAILED | Directory listing failed |
+| PATH_ESCAPE_ATTEMPT | Path escapes workspace boundary |
+| MISSING_UTILITIES | Required system tool not found |
+| INVALID_CONFIGURATION | Configuration validation failed |
+| DANGEROUS_OPERATION | Dangerous command blocked |
+| CONNECTION_CLOSED | Connection lost (remote) |
+| KEY_NOT_FOUND | Key does not exist (memory) |
+
+---
+
+## Command Safety
+
+When dangerous command blocking is enabled, commands MUST be checked against known dangerous patterns before execution. The complete list of blocked patterns, pre-processing rules, and response format is defined in [safety.md](safety.md), which is the source of truth for command safety.
+
+The blocked patterns cover:
+
+- **Destructive operations** -- `rm -rf /`, disk overwrite, filesystem formatting, fork bombs
+- **Privilege escalation** -- `sudo`, `su`
+- **System modification** -- `chmod 777`, `chown root`
+- **Pipe-to-shell** -- `curl | sh`, `wget | bash`
+- **Direct network tools** -- `nc`, `ssh`, `scp`, `rsync`, etc.
+- **Command substitution** -- backticks, `$()`
+- **Remote code execution** -- `eval`
+- **Workspace escape** -- `cd`, `pushd`, `$HOME`, `../`, etc.
+
+See [safety.md](safety.md) for the full regex pattern list.
+
+---
+
+## Operations Logging
+
+Backends MAY support pluggable operations logging for audit and debugging.
+
+### Log Entries
+
+Each log entry MUST include:
+- Timestamp
+- Operation type (exec, read, write, mkdir, etc.)
+- Whether the operation succeeded
+- Duration
+
+Log entries SHOULD include (when applicable):
+- The command or path involved
+- User/workspace context
+- stdout/stderr for exec operations
+- Error details on failure
+
+### Logging Modes
+
+- **standard** -- Log only modifying operations (exec, write, mkdir, delete, touch).
+- **verbose** -- Log all operations including reads.
+
+---
+
+## Adapters
+
+### Vercel AI SDK Adapter
+
+Implementations MAY provide an adapter for the Vercel AI SDK that wraps a backend and exposes its MCP tools in the format expected by the AI SDK.
+
+- The adapter MUST create the appropriate MCP transport based on the backend type (stdio for local/memory, HTTP for remote).
+- The adapter MUST return a Vercel AI SDK-compatible MCP client.
+- The adapter's resources MUST be tracked by the backend for cleanup on destroy.

--- a/registry/agent-backend/0.9.5/daemon.md
+++ b/registry/agent-backend/0.9.5/daemon.md
@@ -1,0 +1,537 @@
+# agentbe-daemon
+
+> Behavioral contract for the agentbe-daemon server process -- endpoints, authentication, transports, scoping, request handling, shutdown, and Docker packaging.
+
+### Daemon-Specific Terminology
+
+**daemon** -- The long-running server process (`agentbe-daemon`) that exposes a workspace over HTTP (MCP) and WebSocket (SSH). Referred to as "the daemon" throughout this document.
+
+**transport** -- A communication channel between clients and the daemon. The daemon supports three transports: stdio (local-only), HTTP (MCP), and WebSocket (SSH).
+
+**host key** -- The SSH host key used by the ephemeral SSH server for SSH-over-WebSocket connections.
+
+**static scope** -- A scope path fixed at daemon startup via CLI argument. All requests inherit this scope.
+
+**dynamic scope** -- A scope path provided per-request via HTTP header. Allows each request to target a different sub-directory.
+
+---
+
+## Operating Modes
+
+The daemon MUST support two operating modes:
+
+### Full Mode (default)
+
+Starts an HTTP server that serves:
+- The MCP endpoint (`POST /mcp`)
+- The health endpoint (`GET /health`)
+- Optionally, the SSH-over-WebSocket endpoint (`WS /ssh`)
+- Optionally, a conventional SSH daemon (sshd)
+
+### Local-Only Mode
+
+Runs an MCP server over stdio with no network listeners. The daemon reads MCP requests from stdin and writes responses to stdout.
+
+- MUST NOT start an HTTP server.
+- MUST NOT start any SSH transport.
+- MUST create a backend from the configured root directory, optionally scoped.
+- MUST NOT enable dangerous command blocking (`preventDangerous`). Local-only mode trusts the local user; only full daemon mode requires command safety enforcement.
+- MUST connect the MCP server to a stdio transport.
+
+---
+
+## Configuration
+
+### CLI Arguments
+
+The daemon MUST be invoked via the `daemon` subcommand: `agent-backend daemon <flags>`. The entrypoint MUST strip the `daemon` subcommand before parsing flags.
+
+All flags use `--kebab-case` with a space separator for the value.
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--rootDir <path>` | string | none | **Yes** | Workspace root directory |
+| `--scopePath <path>` | string | none | No | Static scope path within rootDir |
+| `--isolation <mode>` | enum | `auto` | No | Isolation mode: `auto`, `bwrap`, `software`, `none` |
+| `--shell <shell>` | enum | `auto` | No | Shell preference: `bash`, `sh`, `auto` |
+| `--port <port>` | integer | `3001` | No | HTTP/WebSocket server port |
+| `--auth-token <token>` | string | none | No | Bearer token for authentication |
+| `--local-only` | boolean | `false` | No | Run MCP server via stdio only |
+| `--disable-ssh-ws` | boolean | `false` | No | Disable SSH-over-WebSocket endpoint |
+| `--ssh-host-key <path>` | string | none | No | Path to SSH host key file |
+| `--conventional-ssh` | boolean | `false` | No | Enable conventional SSH daemon |
+| `--ssh-port <port>` | integer | `22` | No | Conventional SSH port |
+| `--ssh-users <users>` | string | `root:agents` | No | Comma-separated `user:pass` pairs |
+| `--ssh-public-key <key>` | string | none | No | SSH public key for first user |
+| `--ssh-authorized-keys <path>` | string | none | No | Path to authorized_keys file for first user |
+
+### Validation Rules
+
+- `--rootDir` MUST be provided. The daemon MUST exit with code 1 if it is missing.
+- `--port` MUST be between 1024 and 65535 inclusive.
+- `--ssh-port` MUST be between 1 and 65535 inclusive.
+- `--isolation` MUST be one of `auto`, `bwrap`, `software`, `none`. The daemon MUST exit with code 1 on an invalid value.
+- `--shell` MUST be one of `bash`, `sh`, `auto`. The daemon MUST exit with code 1 on an invalid value.
+- `--ssh-users` MUST follow the format `user:pass[,user:pass,...]`. The daemon MUST reject entries with a missing user or password.
+- Unrecognized `--` flags MUST cause the daemon to exit with code 1.
+
+### Environment Variables (Docker)
+
+The Docker entrypoint translates the following environment variables to CLI arguments. The daemon itself does not read these directly — they are a Docker-layer convention.
+
+| Variable | Maps to | Default |
+|----------|---------|---------|
+| `WORKSPACE_ROOT` | `--rootDir` | `/var/workspace` |
+| `PORT` | `--port` | `3001` |
+| `AUTH_TOKEN` | `--auth-token` | none |
+| `SSH_HOST_KEY` | `--ssh-host-key` | none |
+| `SHELL_TYPE` | `--shell` | none (auto) |
+| `DISABLE_SSH_WS` | `--disable-ssh-ws` | `false` |
+| `CONVENTIONAL_SSH` | `--conventional-ssh` | `false` |
+| `SSH_PORT` | `--ssh-port` | `22` |
+| `SSH_USERS` | `--ssh-users` | `root:agents` |
+| `SSH_PUBLIC_KEY` | `--ssh-public-key` | none |
+| `USE_LOCAL_BUILD` | (triggers dev hot-reload) | `0` |
+
+The entrypoint MUST also check for `/keys/authorized_keys` and pass it as `--ssh-authorized-keys` if it exists.
+
+---
+
+## Endpoints
+
+### `GET /health`
+
+Health check endpoint. MUST NOT require authentication.
+
+**Response:** HTTP 200 with JSON body:
+
+```json
+{
+  "status": "ok",
+  "version": "<package version>",
+  "rootDir": "<configured rootDir>",
+  "transports": {
+    "mcp": true,
+    "ssh-ws": <boolean>,
+    "ssh": <boolean>
+  }
+}
+```
+
+- `transports.mcp` MUST always be `true`.
+- `transports.ssh-ws` MUST be `true` unless SSH-over-WebSocket is disabled.
+- `transports.ssh` MUST be `true` only when conventional SSH is enabled.
+
+### `POST /mcp`
+
+MCP (Model Context Protocol) endpoint. Handles tool calls against the workspace.
+
+**Authentication:** See [Authentication](#authentication).
+
+**Request headers:**
+- `Authorization` — Bearer token (when auth is configured).
+- `X-Root-Dir` — Optional. If present and not the string `'undefined'`, the daemon MUST verify it matches the configured `rootDir` exactly. On mismatch, the daemon MUST respond with HTTP 403:
+  ```json
+  {
+    "error": "Root directory mismatch",
+    "message": "Server is configured for <rootDir>, not <requested>"
+  }
+  ```
+- `X-Scope-Path` — Optional. Dynamic scope path for this request. See [MCP Request Handling](#mcp-request-handling).
+
+**MCP processing:** Each request MUST be handled by a fresh MCP server and transport instance. See [MCP Request Handling](#mcp-request-handling).
+
+### `WS /ssh`
+
+SSH-over-WebSocket endpoint. Upgrades HTTP connections to WebSocket for SSH transport.
+
+**Path:** `/ssh`
+
+**Authentication:** See [Authentication](#authentication). Authentication MUST occur during the WebSocket `connection` event, before SSH negotiation.
+
+On authentication failure, the daemon MUST close the WebSocket with code `4001` and reason `"Unauthorized"`.
+
+See [SSH-over-WebSocket](#ssh-over-websocket) for full transport details.
+
+---
+
+## Authentication
+
+### Bearer Token Scheme
+
+When an auth token is configured (`--auth-token`), the daemon MUST enforce authentication on the `/mcp` and `/ssh` endpoints. The `/health` endpoint MUST NOT require authentication.
+
+When no auth token is configured, all requests MUST be accepted without authentication.
+
+### MCP Endpoint Authentication
+
+The daemon MUST check the `Authorization` header for the value `Bearer <token>`. The comparison MUST be an exact string match.
+
+On failure, the daemon MUST respond with HTTP 401:
+```json
+{
+  "error": "Unauthorized",
+  "message": "Invalid or missing authentication token"
+}
+```
+
+### SSH-over-WebSocket Authentication
+
+The daemon MUST check for the token in two locations, in order:
+1. Query parameter: `/ssh?token=<token>`
+2. `Authorization` header: `Bearer <token>`
+
+If either matches, authentication succeeds. On failure, the daemon MUST close the WebSocket with code `4001` and reason `"Unauthorized"`.
+
+---
+
+## MCP Request Handling
+
+### Per-Request Backend
+
+Each `POST /mcp` request MUST be handled with its own MCP server and transport instance. The daemon MUST NOT maintain server-side session state between requests.
+
+### Scoping
+
+The daemon supports two scoping mechanisms:
+
+**Static scope** (`--scopePath`): Fixed at startup. All requests inherit this scope path.
+
+**Dynamic scope** (`X-Scope-Path` header): Per-request scope path.
+
+**Conflict handling:** If the daemon was started with a static scope AND the request also provides a dynamic scope, the daemon MUST respond with HTTP 400:
+```json
+{
+  "error": "Scope conflict",
+  "message": "Server was started with static scope '<static>', but request also specified scope '<dynamic>'. Use one or the other, not both."
+}
+```
+
+### Scope Path Validation
+
+The effective scope path (from either source) MUST be validated:
+1. Leading slashes MUST be stripped.
+2. `..` sequences MUST be rejected. If the scope path contains `..` or normalizing it changes the value, the daemon MUST respond with HTTP 400:
+   ```json
+   {
+     "error": "Invalid scope path",
+     "message": "Scope path must not contain path traversal sequences"
+   }
+   ```
+
+### Backend Construction
+
+In full daemon mode, the backend MUST be constructed with dangerous command blocking enabled (`preventDangerous: true`).
+
+If a valid scope path is present, the daemon MUST create a scoped backend from the base backend using the normalized scope path.
+
+### MCP Server Tools
+
+**Important:** The MCP protocol and its official reference servers evolve independently of this spec. Before implementing or updating MCP request handling, the implementer MUST consult the latest [MCP specification](https://spec.modelcontextprotocol.io/), the [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk), and the [official MCP Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) for current transport types, server APIs, tool schemas, and protocol details. The tool list below is a snapshot; the official filesystem server is the source of truth.
+
+The daemon MUST register the tools defined by the [official MCP Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem). Tool names, input schemas, and output formats MUST match the official filesystem MCP server exactly.
+
+At time of writing, the official filesystem MCP server provides the following tools:
+
+| Tool | Description |
+|------|-------------|
+| `read_text_file` | Read file contents as text (with optional `head`/`tail` line limits) |
+| `read_media_file` | Read an image or audio file as base64 |
+| `read_multiple_files` | Read multiple files simultaneously |
+| `write_file` | Create new file or overwrite existing |
+| `edit_file` | Selective edits using `edits: [{ oldText, newText }]` with optional `dryRun` |
+| `create_directory` | Create new directory or ensure it exists |
+| `list_directory` | List directory contents with `[FILE]`/`[DIR]` prefixes |
+| `list_directory_with_sizes` | List directory contents including file sizes, with optional `sortBy` |
+| `directory_tree` | Recursive JSON tree structure with optional `excludePatterns` |
+| `move_file` | Move or rename files and directories |
+| `search_files` | Recursively search for files matching glob patterns, with optional `excludePatterns` |
+| `get_file_info` | Get detailed file/directory metadata |
+| `list_allowed_directories` | List the workspace boundary (allowed directories) |
+
+In addition to the official filesystem tools, the daemon MUST register the following tool when the backend supports command execution:
+
+| Tool | Description |
+|------|-------------|
+| `exec` | Execute a shell command. Parameters: `command` (string, required), `env` (object, optional). |
+
+---
+
+## SSH-over-WebSocket
+
+### WebSocket Upgrade
+
+The daemon MUST listen for WebSocket upgrade requests at the `/ssh` path.
+
+If `--disable-ssh-ws` is set, the daemon MUST NOT create the WebSocket server.
+
+### Duplex Stream Bridging
+
+The daemon MUST create a duplex stream from each WebSocket connection to bridge with the SSH server:
+
+- Writes to the duplex MUST send data via `ws.send()`. If the WebSocket is not in the OPEN state, writes MUST fail with an error.
+- Incoming WebSocket messages MUST be pushed into the readable side of the duplex as Buffers.
+- WebSocket `close` MUST push EOF (null) to the readable side.
+- WebSocket `error` MUST destroy the duplex stream.
+- Calling `final()` on the duplex MUST close the WebSocket with code 1000.
+- Calling `destroy()` on the duplex MUST close the WebSocket with code 1011.
+
+The duplex stream MUST be injected into an SSH server instance for protocol handling.
+
+### SSH Server Per Connection
+
+Each WebSocket connection MUST get its own ephemeral SSH server instance. When the WebSocket closes, the SSH server for that connection is torn down.
+
+### SSH Authentication Passthrough
+
+Once WebSocket-level authentication succeeds, the SSH server MUST accept all SSH authentication methods (password, publickey, none). The rationale is that transport-level token authentication has already been performed.
+
+### Host Key Management
+
+The daemon MUST support loading an SSH host key from a file (`--ssh-host-key`) or auto-generating one.
+
+- **Default path:** `/var/lib/agentbe/ssh_host_ed25519_key`
+- **Key algorithm:** RSA (2048-bit). The key MUST be generated via `generateKeyPairSync('rsa', { modulusLength: 2048 })` (or equivalent) with PKCS#1 PEM encoding.
+- If the file at the configured (or default) path exists, the daemon MUST read and use it.
+- If the file does not exist, the daemon MUST generate a new RSA key pair and attempt to save it for reuse.
+- If the directory cannot be created or the file cannot be written, the daemon MUST use the generated key ephemerally (in-memory only, not persisted). This MUST NOT be a fatal error.
+
+### Session Types
+
+The SSH server MUST handle the following session types:
+
+#### PTY Requests
+
+The daemon MUST accept PTY requests and store the terminal information (term type, columns, rows) for use by subsequent shell or exec requests.
+
+#### Shell Sessions
+
+When a shell session is requested:
+- The daemon SHOULD attempt to use a PTY-capable spawner (e.g., `node-pty`) if available, for proper terminal emulation.
+- If PTY support is unavailable, the daemon MUST fall back to executing the resolved shell as a command.
+- Default terminal type: `xterm-256color`. Default dimensions: 80 columns, 24 rows.
+
+#### Exec Sessions
+
+When a command exec is requested:
+- The daemon MUST spawn the command via the resolved shell with `-c` flag.
+- Working directory MUST be set to the workspace root (or scoped root).
+- Environment MUST include `HOME`, `PWD` (set to the working directory), and `TERM=xterm-256color`.
+- The exit code MUST be sent via the SSH channel's exit method.
+- On spawn failure, the daemon MUST write the error to stderr on the channel and exit with code 1.
+
+#### Window Change
+
+The daemon MUST handle `window-change` session events. These events indicate a PTY resize. The daemon MUST accept the event (call `accept()` if provided). Implementations SHOULD propagate the new dimensions to the active PTY process if one is tracked.
+
+#### SFTP Sessions
+
+The daemon MUST support SFTP sessions. See [SFTP Path Jailing](#sftp-path-jailing).
+
+### Shell Resolution
+
+The daemon MUST resolve the shell to use:
+- `'bash'` → `/bin/bash`
+- `'sh'` → `/bin/sh`
+- `'auto'` or unset → prefer `/bin/bash` if it exists, fall back to `/bin/sh`
+
+---
+
+## SFTP Path Jailing
+
+All SFTP operations MUST be confined to the workspace root directory.
+
+### Path Resolution
+
+For every SFTP operation, the daemon MUST resolve paths as follows:
+1. Normalize the workspace root via an absolute path resolve.
+2. If the requested path already starts with the normalized root (followed by `/` or is equal), use it directly.
+3. Otherwise, strip leading slashes and resolve relative to the workspace root.
+4. After resolution, verify the resolved path starts with the normalized root (followed by `/` or is equal). If not, the operation MUST fail with a path escape error.
+
+### Supported SFTP Operations
+
+The daemon MUST implement the following SFTP operations:
+
+| Operation | Notes |
+|-----------|-------|
+| OPEN | Auto-create parent directories for write operations. Default file mode: `0o644`. SFTP open flags MUST be translated to OS-level flags (e.g., `SSH2_FXF_READ` → `O_RDONLY`, `SSH2_FXF_WRITE` → `O_WRONLY`, `SSH2_FXF_CREAT` → `O_CREAT`, `SSH2_FXF_TRUNC` → `O_TRUNC`, `SSH2_FXF_EXCL` → `O_EXCL`, `SSH2_FXF_APPEND` → `O_APPEND`). Flags MUST be combined bitwise. |
+| READ | Return `EOF` status when zero bytes are read. |
+| WRITE | Write at specified offset. |
+| CLOSE | Close file handle and free the handle ID. |
+| FSTAT | Stat an open file handle. |
+| OPENDIR | Read directory entries into memory. |
+| READDIR | Return entries in batches. Return `EOF` status when exhausted. |
+| STAT | Stat a path (follows symlinks). |
+| LSTAT | Stat a path (does not follow symlinks). |
+| REALPATH | Return the resolved path relative to the workspace root, presented to the client as an absolute path from `/`. |
+| MKDIR | Default mode: `0o755`. |
+| RMDIR | Remove an empty directory. |
+| REMOVE | Delete a file. |
+| RENAME | Auto-create parent directory of destination. Both paths MUST be validated within the workspace root. |
+| SETSTAT | Support chmod. Chown and utimes MAY silently ignore errors. |
+| FSETSTAT | Same as SETSTAT but on an open file handle. |
+
+### Error Mapping
+
+SFTP errors MUST be mapped from OS error codes:
+- `ENOENT` → `NO_SUCH_FILE`
+- `EACCES` → `PERMISSION_DENIED`
+- All other errors → `FAILURE`
+
+---
+
+## Conventional SSH (Opt-In)
+
+The daemon MAY support running a conventional SSH daemon (sshd) alongside the HTTP server.
+
+### Platform Requirements
+
+- `--conventional-ssh` MUST require Linux (`process.platform === 'linux'`). The daemon MUST exit with code 1 on other platforms.
+- `--conventional-ssh` SHOULD require root privileges. The daemon SHOULD print a warning if not running as root.
+- The daemon MUST verify `/usr/sbin/sshd` exists. If missing, the daemon MUST exit with code 1.
+
+### User Setup
+
+When conventional SSH is enabled, the daemon MUST:
+1. Create Linux users from the `--ssh-users` list using `useradd -m -s /bin/bash`.
+2. Set passwords via `chpasswd`.
+3. Create `.ssh` directories with mode `700` and `authorized_keys` files with mode `600`.
+4. Apply `--ssh-public-key` and `--ssh-authorized-keys` to the first user only.
+5. Enable password authentication via an sshd configuration drop-in file.
+
+### sshd Process
+
+The daemon MUST spawn sshd with `-D` (foreground) and `-e` (log to stderr) flags on the configured port.
+
+If sshd exits unexpectedly, the daemon MUST close the HTTP server and exit with code 1.
+
+---
+
+## Graceful Shutdown
+
+The daemon MUST handle `SIGTERM` and `SIGINT` for graceful shutdown.
+
+### Close Ordering
+
+On receiving a shutdown signal, the daemon MUST close resources in the following order:
+
+1. **SSH-over-WebSocket server** — Close all active WebSocket clients with code 1000 and reason `"Server shutting down"`, then close the WebSocket server.
+2. **HTTP server** — Stop accepting new connections and close the HTTP server.
+3. **Conventional sshd** (if running) — Send `SIGTERM` to the sshd process and wait for it to exit.
+4. **Exit** — Exit the process with code 0.
+
+---
+
+## Docker Image
+
+### Base Image
+
+The Docker image MUST use `ubuntu:22.04` as the base image.
+
+### Build Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `INCLUDE_SSHD` | `true` | Include openssh-server |
+| `AGENTBE_VERSION` | `local` | Package version or `local` for local build |
+
+### Installed Tooling
+
+The image MUST include:
+- `sudo`, `curl`, `wget`, `tree`, `ripgrep`, `git`
+- `python3`, `python3-pip`
+- Node.js 20 (via nodesource)
+- `pnpm`, `tsx` (global npm packages)
+- `agent-backend` (from npm or local build)
+- `openssh-server` (when `INCLUDE_SSHD=true`)
+
+### Build-Time SSH Configuration
+
+When `INCLUDE_SSHD=true`, the image MUST configure sshd at build time:
+
+1. Create `/var/run/sshd` and `/run/sshd` directories.
+2. Generate SSH host keys (`ssh-keygen -A`).
+3. Modify `/etc/ssh/sshd_config`:
+   - `PermitRootLogin yes`
+   - `PasswordAuthentication yes`
+   - `PubkeyAuthentication yes`
+   - `ListenAddress 0.0.0.0`
+4. Create an sshd config drop-in file (`/etc/ssh/sshd_config.d/agentbe.conf`) with:
+   - `PasswordAuthentication yes`
+   - `PermitRootLogin yes`
+   - `ChallengeResponseAuthentication yes`
+   - `MaxSessions 64`
+   - `MaxStartups 10:30:100`
+   - `ClientAliveInterval 60`
+   - `ClientAliveCountMax 3`
+5. Configure PAM: change `pam_loginuid.so` from `required` to `optional` in `/etc/pam.d/sshd`.
+6. Create `/root/.ssh` (mode `700`) with an empty `authorized_keys` file (mode `600`).
+7. Set the default root password (`root:agents`) via `chpasswd`.
+
+### Workspace Directory
+
+The image MUST create `/var/workspace` with mode `755`, owned by `root:root`.
+
+### Exposed Ports
+
+- `3001` — MCP + SSH-over-WebSocket
+- `22` — Conventional SSH
+
+### Health Check
+
+The image MUST define a health check:
+- Command: `curl -f http://localhost:${PORT:-3001}/health`
+- Interval: 30 seconds
+- Timeout: 10 seconds
+- Start period: 5 seconds
+- Retries: 3
+
+### Entrypoint Behavior
+
+The entrypoint script (`/docker-entrypoint.sh`) MUST:
+
+1. If invoked as `agent-backend daemon`:
+   a. Strip the `agent-backend daemon` prefix (`shift 2`) so remaining args can be passed through.
+   b. Create the `WORKSPACE_ROOT` directory (default `/var/workspace`) with mode `755`.
+   c. Run all executable `*.sh` scripts in `/docker-entrypoint.d/`, sorted by version sort. Non-executable `.sh` files and non-`.sh` files SHOULD be logged as ignored.
+   d. Translate environment variables to CLI arguments. Arguments MUST be stored in a bash array (not a string) to safely handle values containing spaces.
+   e. Change to `WORKSPACE_ROOT`.
+   f. Execute the daemon via `exec` so the daemon process replaces the shell and becomes PID 1 in the container. This is critical for proper signal handling (SIGTERM, SIGINT). Any remaining positional args (`"$@"`) MUST be appended to allow Docker CMD overrides to pass additional flags.
+2. For any other command, execute it directly via `exec "$@"`.
+
+The entrypoint MUST use `set -e` (fail on any error).
+
+### Extension Points
+
+The image MUST support three extension mechanisms:
+
+1. **`FROM` + `RUN`** — Extend the image with additional packages via a downstream Dockerfile.
+2. **`/docker-entrypoint.d/*.sh`** — Drop-in init scripts executed at container startup before the daemon starts.
+3. **`CMD` override** — Replace the default command entirely.
+
+### Dev Hot-Reload
+
+When `USE_LOCAL_BUILD=1` and the local source directory exists at `/app/agent-backend/src`, the entrypoint MUST use `tsx --watch` to run the daemon from source with automatic restart on file changes.
+
+---
+
+## Security Considerations
+
+### Path Jailing
+
+All file operations — whether via MCP tools, SFTP, or shell execution — MUST be confined to the workspace root directory. Path traversal attempts (`..`) MUST be detected and rejected at every layer (MCP scope validation, SFTP path resolution, backend path resolution).
+
+### Command Isolation
+
+In full daemon mode, the backend MUST be configured with dangerous command blocking enabled. The daemon delegates command safety enforcement to the backend layer (see [Command Safety](safety.md) for the full list of blocked patterns).
+
+### Authentication Token Recommendations
+
+- Deployments exposed to the network SHOULD configure an auth token.
+- Auth tokens SHOULD be generated with sufficient entropy (e.g., 256-bit random).
+- Tokens are compared via exact string match. Implementations SHOULD use constant-time comparison to prevent timing attacks.
+
+### SSH Host Key Stability
+
+For production deployments, operators SHOULD provide a persistent host key via `--ssh-host-key` to prevent host key mismatch warnings on client reconnection. Auto-generated keys are ephemeral when the file cannot be persisted, meaning clients will see a different host key each time the daemon restarts.

--- a/registry/agent-backend/0.9.5/manifest.json
+++ b/registry/agent-backend/0.9.5/manifest.json
@@ -1,13 +1,7 @@
 {
   "name": "agent-backend",
+  "version": "0.9.5",
+  "specFormat": "0.1.0",
   "description": "Client library and server daemon providing a unified API for agent-filesystem interaction within local or remote sandboxed workspaces",
-  "latest": "0.9.5",
-  "versions": {
-    "0.9.0": {
-      "spec_format": "0.1.0"
-    },
-    "0.9.5": {
-      "specFormat": "0.1.0"
-    }
-  }
+  "dependencies": []
 }

--- a/registry/agent-backend/0.9.5/safety.md
+++ b/registry/agent-backend/0.9.5/safety.md
@@ -1,0 +1,96 @@
+# Command Safety
+
+> Behavioral contract for command safety validation -- pre-processing rules, dangerous command patterns, workspace escape patterns, and response format.
+
+Both the [daemon spec](daemon.md) and [client spec](clients.md) reference this document for the complete list of blocked patterns. When dangerous command blocking is enabled, commands MUST be checked against the patterns defined here before execution.
+
+---
+
+## Pre-processing
+
+- Commands MUST be normalized to lowercase before pattern matching.
+- Heredoc content MUST be stripped before safety validation to prevent false positives (heredocs contain literal data, not executable commands).
+- Implementations MAY define allowed patterns that override specific blocked patterns. The default allowlist MUST include `gcloud rsync` (a gcloud subcommand, not the `rsync` binary).
+- Allowed patterns MUST be checked before dangerous patterns; if a command matches an allowed pattern, it is not dangerous.
+
+---
+
+## Dangerous Command Patterns
+
+The following regex patterns MUST be blocked. Each pattern uses `\b` for word boundaries where appropriate.
+
+**Destructive operations:**
+- `\brm\b.*-rf?\b.*[/~*]` and `\brm\b.*[/~*].*-rf?\b` -- system-wide destructive rm
+- `\bdd\b.*\bof=\/dev\/` -- disk wiping with dd
+
+**Privilege escalation:**
+- `\bsudo\b`, `\bsu\b`
+
+**System modification:**
+- `\bchmod\b.*777`, `\bchown\b.*root`
+
+**Pipe-to-shell (download-and-execute):**
+- `curl\b.*\|\s*(sh|bash|zsh|fish)\b`
+- `wget\b.*\|\s*(sh|bash|zsh|fish)\b`
+- `\|\s*(sh|bash|zsh|fish)\s*$`
+
+**Direct network tools:**
+- `\bnc\b`, `\bncat\b`, `\bnetcat\b`, `\btelnet\b`, `\bftp\b`, `\bssh\b`, `\bscp\b`, `\brsync\b`
+
+**Process and system control:**
+- `\bkill\s+-9`, `\bkillall\b`, `\bpkill\b`
+- `\bshutdown\b`, `\breboot\b`, `\bhalt\b`, `\binit\s+[06]\b`
+
+**Filesystem manipulation:**
+- `\bmount\b`, `\bumount\b`, `\bfdisk\b`, `\bmkfs\b`, `\bfsck\b`
+
+**Command substitution:**
+- `` `[^`]+` `` -- backtick substitution
+- `\$\([^)]+\)` -- `$()` substitution
+
+**Remote code execution:**
+- `\beval\b`
+
+**Resource exhaustion:**
+- `:\(\)` -- fork bomb pattern
+- `fork\(\)`
+- `\bwhile\s+true\b`
+- `\byes\b.*>\s*\/dev\/null`
+
+**Network tampering:**
+- `\biptables\b`
+- `\bifconfig\b.*\bdown\b`
+
+**System file modification:**
+- `>>?\s*\/etc\/`, `>\s*\/etc\/`
+- `\bcat\b.*>\s*\/etc\/`, `\becho\b.*>\s*\/etc\/`
+
+**Obfuscation:**
+- `[a-z]""[a-z]` -- string obfuscation (e.g., `r""m`)
+
+**Path traversal in sensitive operations:**
+- `\b(cp|mv|ln)\b.*\.\.\/`
+
+**Symbolic link creation:**
+- `\bln\s+-s`
+
+---
+
+## Workspace Escape Patterns
+
+Implementations SHOULD also block commands that attempt to escape the workspace. The following patterns MUST be checked (after heredoc stripping):
+
+- `\bcd\b`, `\bpushd\b`, `\bpopd\b` -- directory change commands
+- `export\s+PATH=`, `export\s+HOME=`, `export\s+PWD=` -- environment manipulation
+- `~\/` -- home directory reference
+- `\$HOME`, `\$\{HOME\}` -- HOME variable references
+- `\.\.[/\\]` -- parent directory traversal
+- `` `[^`]+` ``, `\$\([^)]+\)` -- command substitution (may be used to escape)
+
+---
+
+## Safety Check Response
+
+When a command is blocked, the response MUST include:
+- A `safe: false` status.
+- A `reason` string. Implementations SHOULD provide specific guidance for common cases (e.g., for pipe-to-shell: "Download to a file first, inspect it, then execute if safe").

--- a/registry/agent-backend/0.9.5/spec.md
+++ b/registry/agent-backend/0.9.5/spec.md
@@ -1,0 +1,73 @@
+# agent-backend
+
+> Client library and server daemon providing a unified API for agent-filesystem interaction within local or remote sandboxed workspaces.
+
+## Overview
+
+Agent Backend is composed of three independently spec'd components. Each component spec is self-contained and defines a complete behavioral contract using [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) requirement keywords.
+
+- **[Client Libraries](clients.md)** -- Behavioral contract for all client implementations (TypeScript, Python, etc.). Covers backend types, connection lifecycle, file operations, command execution, scoping, MCP integration, connection pooling, error handling, operations logging, and adapters.
+- **[agentbe-daemon](daemon.md)** -- Behavioral contract for the server-side daemon process. Covers operating modes, configuration, HTTP/WebSocket endpoints, authentication, MCP request handling, SSH-over-WebSocket, SFTP, conventional SSH, graceful shutdown, and Docker packaging.
+- **[Command Safety](safety.md)** -- Behavioral contract for command safety validation. Covers pre-processing rules, dangerous command patterns, workspace escape patterns, and response format. Referenced by both the client and daemon specs.
+
+## Terminology
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are used as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+**Backend** -- A client-side object that provides file operations, command execution, and MCP tool access against a workspace (local directory or remote server). Implementations SHOULD define a base Backend interface that all backend types implement. Operations that only apply to file-based backends (e.g., exec) MAY be separated into a more specific interface.
+
+**Scoped Backend** -- A backend wrapper that restricts operations to a subdirectory of the parent's workspace. Scoped backends delegate operations to their parent after translating paths. Implementations SHOULD treat scoped backends as a distinct type from the backends they wrap, since they have different lifecycle semantics (e.g., destroy does not release resources, status is delegated).
+
+**Workspace** -- The root directory a backend operates within. All paths are relative to this root.
+
+**Scope** -- A restricted view of a backend, rooted at a subdirectory of the parent's workspace. Used for multi-tenant isolation.
+
+**agentbe-daemon** -- The server process that runs on a host and serves the workspace via MCP and SSH over WebSockets.
+
+## Behavioral Contract
+
+The full behavioral contract is defined across the three component specs linked above. Each component spec is self-contained and independently implementable.
+
+### Client Libraries
+
+Defines the behavioral contract for backend types (local filesystem, remote filesystem, memory), their connection lifecycle, file operations, command execution with safety validation and isolation, workspace scoping for multi-tenant isolation, MCP integration, connection pooling, error handling, operations logging, and Vercel AI SDK adapters.
+
+Implementations MUST use idiomatic patterns for their language (e.g., Python may use `async with` for lifecycle, TypeScript may use `await destroy()`). The exact method names, parameter ordering, and error handling idioms are left to each implementation, but the semantics described in [clients.md](clients.md) MUST be preserved.
+
+See the complete [Client Libraries spec](clients.md).
+
+### agentbe-daemon
+
+Defines the behavioral contract for the daemon's two operating modes (full HTTP server and local-only stdio), CLI configuration, HTTP and WebSocket endpoints, bearer token authentication, per-request MCP handling with dynamic scoping, SSH-over-WebSocket transport with SFTP path jailing, optional conventional SSH, graceful shutdown ordering, and Docker image packaging.
+
+The exact framework or runtime (Express, Fastify, etc.) is an implementation detail left to each language. Implementations MUST conform to the semantics described in [daemon.md](daemon.md).
+
+See the complete [agentbe-daemon spec](daemon.md).
+
+### Command Safety
+
+Defines the pre-processing rules (lowercase normalization, heredoc stripping, allowlist), the complete list of dangerous command regex patterns (destructive operations, privilege escalation, pipe-to-shell, network tools, command substitution, etc.), workspace escape patterns, and the required response format when a command is blocked.
+
+Both the [Client Libraries](clients.md) and [agentbe-daemon](daemon.md) specs reference this document for command safety enforcement. See the complete [Command Safety spec](safety.md).
+
+## NOT Specified (Implementation Freedom)
+
+- Programming language for implementations (TypeScript and Python exist today; others may follow)
+- Exact method names, parameter ordering, and error handling idioms (language-idiomatic patterns are preferred)
+- Internal data structures and algorithms
+- Caching strategies
+- Logging implementation details beyond the specified log entry format
+- Test framework and test runner
+- CI/CD pipeline configuration
+- Package manager choice
+- HTTP framework for the daemon (Express, Fastify, etc.)
+
+## Invariants
+
+- All file operations MUST be confined to the workspace root directory (path jailing)
+- Scoped backends MUST NOT access paths outside their scope, even if valid within the parent workspace
+- Backend status MUST follow the defined state machine transitions and MUST NOT skip states
+- Destroying a backend MUST release all associated resources
+- MCP tool names and schemas MUST match the official MCP Filesystem Server
+- Command safety validation MUST occur before command execution when dangerous command blocking is enabled
+- All RFC 2119 keywords in component specs are binding requirements

--- a/skills/agent-backend/SKILL.md
+++ b/skills/agent-backend/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: agent-backend
+description: "Client library and server daemon providing a unified API for agent-filesystem interaction within local or remote sandboxed workspaces."
+---
+# agent-backend
+
+> Client library and server daemon providing a unified API for agent-filesystem interaction within local or remote sandboxed workspaces.
+
+## Overview
+
+Agent Backend is composed of three independently spec'd components. Each component spec is self-contained and defines a complete behavioral contract using [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) requirement keywords.
+
+- **[Client Libraries](clients.md)** -- Behavioral contract for all client implementations (TypeScript, Python, etc.). Covers backend types, connection lifecycle, file operations, command execution, scoping, MCP integration, connection pooling, error handling, operations logging, and adapters.
+- **[agentbe-daemon](daemon.md)** -- Behavioral contract for the server-side daemon process. Covers operating modes, configuration, HTTP/WebSocket endpoints, authentication, MCP request handling, SSH-over-WebSocket, SFTP, conventional SSH, graceful shutdown, and Docker packaging.
+- **[Command Safety](safety.md)** -- Behavioral contract for command safety validation. Covers pre-processing rules, dangerous command patterns, workspace escape patterns, and response format. Referenced by both the client and daemon specs.
+
+## Terminology
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are used as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+**Backend** -- A client-side object that provides file operations, command execution, and MCP tool access against a workspace (local directory or remote server). Implementations SHOULD define a base Backend interface that all backend types implement. Operations that only apply to file-based backends (e.g., exec) MAY be separated into a more specific interface.
+
+**Scoped Backend** -- A backend wrapper that restricts operations to a subdirectory of the parent's workspace. Scoped backends delegate operations to their parent after translating paths. Implementations SHOULD treat scoped backends as a distinct type from the backends they wrap, since they have different lifecycle semantics (e.g., destroy does not release resources, status is delegated).
+
+**Workspace** -- The root directory a backend operates within. All paths are relative to this root.
+
+**Scope** -- A restricted view of a backend, rooted at a subdirectory of the parent's workspace. Used for multi-tenant isolation.
+
+**agentbe-daemon** -- The server process that runs on a host and serves the workspace via MCP and SSH over WebSockets.
+
+## Behavioral Contract
+
+The full behavioral contract is defined across the three component specs linked above. Each component spec is self-contained and independently implementable.
+
+### Client Libraries
+
+Defines the behavioral contract for backend types (local filesystem, remote filesystem, memory), their connection lifecycle, file operations, command execution with safety validation and isolation, workspace scoping for multi-tenant isolation, MCP integration, connection pooling, error handling, operations logging, and Vercel AI SDK adapters.
+
+Implementations MUST use idiomatic patterns for their language (e.g., Python may use `async with` for lifecycle, TypeScript may use `await destroy()`). The exact method names, parameter ordering, and error handling idioms are left to each implementation, but the semantics described in [clients.md](clients.md) MUST be preserved.
+
+See the complete [Client Libraries spec](clients.md).
+
+### agentbe-daemon
+
+Defines the behavioral contract for the daemon's two operating modes (full HTTP server and local-only stdio), CLI configuration, HTTP and WebSocket endpoints, bearer token authentication, per-request MCP handling with dynamic scoping, SSH-over-WebSocket transport with SFTP path jailing, optional conventional SSH, graceful shutdown ordering, and Docker image packaging.
+
+The exact framework or runtime (Express, Fastify, etc.) is an implementation detail left to each language. Implementations MUST conform to the semantics described in [daemon.md](daemon.md).
+
+See the complete [agentbe-daemon spec](daemon.md).
+
+### Command Safety
+
+Defines the pre-processing rules (lowercase normalization, heredoc stripping, allowlist), the complete list of dangerous command regex patterns (destructive operations, privilege escalation, pipe-to-shell, network tools, command substitution, etc.), workspace escape patterns, and the required response format when a command is blocked.
+
+Both the [Client Libraries](clients.md) and [agentbe-daemon](daemon.md) specs reference this document for command safety enforcement. See the complete [Command Safety spec](safety.md).
+
+## NOT Specified (Implementation Freedom)
+
+- Programming language for implementations (TypeScript and Python exist today; others may follow)
+- Exact method names, parameter ordering, and error handling idioms (language-idiomatic patterns are preferred)
+- Internal data structures and algorithms
+- Caching strategies
+- Logging implementation details beyond the specified log entry format
+- Test framework and test runner
+- CI/CD pipeline configuration
+- Package manager choice
+- HTTP framework for the daemon (Express, Fastify, etc.)
+
+## Invariants
+
+- All file operations MUST be confined to the workspace root directory (path jailing)
+- Scoped backends MUST NOT access paths outside their scope, even if valid within the parent workspace
+- Backend status MUST follow the defined state machine transitions and MUST NOT skip states
+- Destroying a backend MUST release all associated resources
+- MCP tool names and schemas MUST match the official MCP Filesystem Server
+- Command safety validation MUST occur before command execution when dangerous command blocking is enabled
+- All RFC 2119 keywords in component specs are binding requirements

--- a/skills/agent-backend/clients.md
+++ b/skills/agent-backend/clients.md
@@ -1,0 +1,484 @@
+# Client Libraries
+
+> Language-agnostic behavioral contract for the Agent Backend client library API.
+
+## Backend Types
+
+### Filesystem Backend (Local)
+
+Operates directly on the local filesystem using OS-level APIs. Status is always "connected" until destroyed.
+
+Configuration:
+- Workspace root directory (required)
+- Isolation mode (auto, bwrap, software, none)
+- Whether to block dangerous commands (default: true)
+- Maximum output length for command execution
+- Shell preference (bash, sh, auto)
+
+### Filesystem Backend (Remote)
+
+Same operations as local, but executed on a remote host via SSH (for file ops) and MCP over HTTP (for tool calls). Requires explicit connection and supports reconnection.
+
+Configuration:
+- Workspace root directory on the remote host (required)
+- Remote host (required)
+- Transport type: SSH-over-WebSocket (default) or conventional SSH (optional to support)
+- Authentication credentials (token for WebSocket/MCP; password or key-based for conventional SSH)
+- MCP server port
+- Reconnection settings (max retries, backoff)
+- Operation timeout
+- Keepalive interval
+
+### Memory Backend
+
+In-memory key/value store. Keys act as pseudo file paths. Does NOT support command execution.
+
+Configuration:
+- Root prefix (optional, default "/")
+- Initial data to pre-populate the store
+
+---
+
+## Connection Lifecycle
+
+Backends have a status that reflects their connection state. All backend types MUST expose the same connection status API — the same status property, the same status enum, and the same `onStatusChange` subscription method — regardless of whether the backend actually has meaningful status transitions. This allows host applications to write generic code that handles any backend type without branching on backend kind. For example, a UI can bind a single status indicator to `backend.status` and `backend.onStatusChange()` and have it work identically for local, remote, and memory backends.
+
+### Status Values
+
+- **connected** -- Normal operating state.
+- **connecting** -- Initial connection in progress.
+- **disconnected** -- No active connection (remote only).
+- **reconnecting** -- Retrying after connection loss (remote only).
+- **destroyed** -- Backend has been torn down. No further operations allowed.
+
+### Behavior by Backend Type
+
+**Local filesystem:**
+- MUST start in "connected" status.
+- MUST transition to "destroyed" on destroy.
+- MUST NOT have any other status transitions.
+
+**Remote filesystem:**
+- MUST start in "disconnected" status.
+- MUST transition to "connecting" on first operation or explicit connect call.
+- MUST transition to "connected" on successful connection.
+- SHOULD attempt reconnection on connection loss if reconnection is enabled.
+- MUST transition to "reconnecting" during retry attempts.
+- MUST transition to "destroyed" on destroy.
+- MUST reject all pending operations when connection is lost.
+
+**Memory:**
+- MUST start in "connected" status.
+- MUST transition to "destroyed" on destroy.
+
+### Status Observation
+
+Implementations MUST provide a way to subscribe to status changes. Callbacks MUST fire on every status transition.
+
+### Reconnection Behavior (Remote Backends)
+
+Remote backends maintain two independent channels to the daemon: an SSH channel (for file operations and exec) and an MCP channel (HTTP, for tool calls). These channels have different failure and retry semantics.
+
+#### SSH Channel
+
+The SSH channel (SSH-over-WebSocket or conventional SSH) is a persistent connection. Implementations MUST detect connection loss via transport-level events (WebSocket `close`, SSH `close`) and keepalive failures.
+
+**Keepalive:** Implementations SHOULD send SSH keepalive probes at a configurable interval (default: 30 seconds). After a configurable number of missed responses (default: 3), the connection MUST be considered dead and closed.
+
+**On disconnection:**
+1. MUST immediately reject all pending operations with a connection-closed error.
+2. MUST clear any cached transport state (e.g., SFTP sessions).
+3. MUST transition status to "disconnected".
+4. MUST schedule a reconnection attempt if reconnection is enabled.
+
+**Reconnection:** Implementations MUST support automatic reconnection with exponential backoff. The reconnection configuration MUST include:
+- Whether reconnection is enabled (default: true)
+- Maximum retry count (default: 5; 0 means unlimited)
+- Initial delay (default: 1000ms)
+- Maximum delay cap (default: 30000ms)
+- Backoff multiplier (default: 2)
+
+The delay sequence follows `min(initialDelay * multiplier^attempt, maxDelay)`. On successful reconnection, the retry counter MUST reset to zero and status MUST transition to "connected". If max retries are exhausted, the backend MUST remain in "disconnected" status and stop retrying.
+
+If `destroy()` is called while a reconnection is pending, the scheduled retry MUST be cancelled.
+
+#### MCP Channel (HTTP)
+
+The MCP channel uses stateless HTTP requests. There is no persistent connection and no daemon-side session state. Each tool call is an independent HTTP request to the daemon's MCP endpoint.
+
+If an MCP request fails (network error, timeout, non-2xx response), the error MUST propagate to the caller. Implementations MUST NOT automatically retry MCP requests — the caller (typically the AI SDK or application layer) is responsible for retry decisions.
+
+#### Daemon-Side Connection Handling
+
+The daemon does not maintain long-lived client sessions. Each channel is independent:
+
+**SSH-over-WebSocket:** Each incoming WebSocket connection gets its own ephemeral SSH server instance. When the WebSocket closes, the SSH server for that connection is torn down. Spawned child processes (from exec) are not explicitly killed — they terminate naturally when their I/O pipes break.
+
+**MCP over HTTP:** Each HTTP request is handled independently with no server-side session state. There is nothing to clean up when a client disappears.
+
+This stateless daemon design means the client is always responsible for reconnection. The daemon does not track clients, send heartbeats, or attempt to notify clients of impending disconnection. If the daemon process itself restarts, all WebSocket connections drop and clients detect this through their normal disconnection handling.
+
+---
+
+## Destroy / Resource Cleanup
+
+Every backend MUST provide a destroy operation that tears down all resources.
+
+### Behavior
+
+- MUST close all MCP clients and transports created via the backend's MCP integration methods.
+- MUST close all resources registered via the closeable tracking mechanism (see below).
+- MUST set status to "destroyed".
+- SHOULD be idempotent (calling destroy twice MUST NOT throw).
+- For remote backends: MUST cancel any pending reconnection attempts, reject all pending operations, and close SSH/WebSocket connections.
+- MUST NOT destroy child scoped backends automatically. Children become orphaned when the parent is destroyed.
+
+### Closeable Tracking
+
+Backends MUST provide a way to register external closeable resources (objects with a close method). These resources MUST be closed when the backend is destroyed. This is used internally for MCP clients and transports, and MAY be used by consumers for their own resources.
+
+---
+
+## File Operations
+
+All file-based backends (local, remote, and memory) MUST support the following operations. Paths are always relative to the backend's workspace root unless otherwise noted.
+
+### Path Resolution
+
+Path handling follows the three-case resolution logic and escape prevention rules defined in [docs/filepaths.md](../docs/filepaths.md), which is the source of truth for path behavior. In summary:
+
+- Relative paths MUST be resolved against the workspace root.
+- Absolute paths that match the workspace root MUST be used directly.
+- Absolute paths that do NOT match the workspace root MUST be treated as relative (leading slash stripped).
+- Paths containing `..` that would escape the workspace MUST be rejected with a path escape error.
+- These rules apply at every scope level for scoped backends.
+
+See [docs/filepaths.md](../docs/filepaths.md) for detailed examples, backend-specific path module conventions, and scoped workspace behavior.
+
+### read(path)
+
+Read the contents of a file.
+
+- MUST return file contents as text (default) or raw bytes.
+- MUST throw if the file does not exist.
+- Implementations SHOULD support an encoding option to choose between text and binary output.
+
+### write(path, content)
+
+Write content to a file, creating or overwriting it.
+
+- MUST accept text or binary content.
+- MUST create parent directories automatically if they do not exist.
+- MUST throw on write failure.
+
+### readdir(path)
+
+List the immediate children of a directory.
+
+- MUST return a list of entry names (not full paths).
+- For memory backends: MUST simulate directory listing via prefix matching on keys, returning only immediate children (first path segment after the prefix).
+
+### mkdir(path)
+
+Create a directory.
+
+- MUST support recursive creation (create intermediate directories).
+- For memory backends: MUST be a no-op (directories are implicit in key structure).
+
+### exists(path)
+
+Check whether a file or directory exists.
+
+- MUST return a boolean.
+- MUST NOT throw if the path does not exist.
+
+### stat(path)
+
+Get metadata about a file or directory.
+
+- MUST return at minimum: whether it is a file or directory, size in bytes, and modification timestamp.
+- For memory backends: MUST return synthetic stats based on the stored value.
+
+### rm(path)
+
+Delete a file or directory.
+
+- MUST support a recursive option for deleting directories and their contents.
+- MUST support a force option that suppresses errors when the target does not exist.
+- For memory backends with recursive mode: MUST delete the exact key and all keys sharing the prefix.
+
+### rename(oldPath, newPath)
+
+Move or rename a file.
+
+- Both paths MUST be validated against the workspace boundary.
+
+### touch(path)
+
+Create an empty file if it does not exist.
+
+- MUST NOT overwrite existing files.
+- For memory backends: MUST create the key with an empty value if it does not exist.
+
+---
+
+## Command Execution
+
+### exec(command)
+
+Execute a shell command within the workspace.
+
+- MUST run the command in a shell (bash preferred, sh as fallback).
+- MUST set the working directory to the workspace root (or the scope root for scoped backends).
+- MUST set the HOME environment variable to the working directory.
+- MUST return the command's standard output as text (default) or raw bytes.
+- MUST throw if the command exits with a non-zero exit code. The error SHOULD include stderr (or stdout if stderr is empty).
+- Implementations SHOULD support an encoding option (text vs binary output).
+- Implementations SHOULD support a custom working directory option, validated to be within the workspace.
+- Implementations SHOULD support custom environment variables per invocation.
+- Memory backends MUST throw a not-implemented error.
+
+### Output Limits
+
+If a maximum output length is configured:
+- MUST truncate output that exceeds the limit.
+- SHOULD append a message indicating truncation occurred and the original output length.
+
+### Safety Validation
+
+When dangerous command blocking is enabled (default):
+- MUST check commands against known dangerous patterns before execution.
+- MUST reject dangerous commands with an appropriate error.
+- See [Command Safety](#command-safety) for the full list of blocked patterns.
+
+### Isolation
+
+Implementations SHOULD support isolation modes for sandboxing command execution:
+
+- **auto** (default) -- Detect the best available isolation method. SHOULD use bwrap if available on Linux, falling back to software validation.
+- **bwrap** (Linux) -- Namespace isolation via bubblewrap. See [bwrap details](#bwrap-sandbox) below.
+- **software** -- Heuristic-based command and path validation only. Works on all platforms.
+- **none** -- No isolation. Trust mode for controlled environments.
+
+#### bwrap Sandbox
+
+When bwrap isolation is active, commands MUST be executed inside a bubblewrap sandbox with the following configuration:
+
+**Filesystem mounts:**
+- System directories (`/usr`, `/lib`, `/lib64`, `/bin`, `/sbin`) MUST be mounted read-only.
+- The workspace root directory MUST be mounted read-write at a sandbox path (e.g., `/tmp/agentbe-workspace`).
+- `/dev`, `/proc` MUST be provided as isolated mounts.
+- `/tmp` MUST be provided as an isolated tmpfs.
+
+**Namespace isolation:**
+- All namespaces MUST be unshared (`--unshare-all`).
+- Network access MUST be preserved (`--share-net`).
+- The sandbox process MUST be killed if the parent process dies (`--die-with-parent`).
+
+**Working directory:**
+- The working directory inside the sandbox MUST correspond to the workspace root (or scope root for scoped backends), mapped to the sandbox mount path.
+- HOME MUST be set to the sandbox working directory.
+
+**Detection:**
+- When isolation mode is `auto`, implementations SHOULD check for bwrap availability (e.g., `command -v bwrap`) and fall back to `software` if not found.
+- When isolation mode is explicitly `bwrap`, implementations MUST throw an error if bwrap is not available.
+
+---
+
+## Scoping
+
+Scoping creates a restricted sub-backend rooted at a subdirectory of the parent workspace. This is the primary mechanism for multi-tenant isolation.
+
+### Creating a Scope
+
+- MUST accept a relative path within the parent workspace.
+- MUST validate that the scope path does not escape the parent workspace.
+- MAY accept custom environment variables that apply to all commands executed within the scope.
+- MAY accept an operations logger for the scope.
+
+### Scoped Backend Behavior
+
+- All file operations MUST be translated to the parent's path space by prepending the scope path.
+- exec() MUST set the working directory to the scope's root directory.
+- Environment variables MUST be merged: scope env as base, per-command env as override.
+- Path validation MUST be applied at the scope level. Paths that escape the scope MUST be rejected, even if they would be valid within the parent.
+- The scope's status MUST be inherited from the parent dynamically (via getter, not copied at construction time).
+- Scoped backends MUST delegate closeable tracking to the root backend.
+- On first write operation, the scope MUST ensure its root directory exists (create if needed). This MUST be deduped to prevent concurrent creation.
+
+### Nested Scoping
+
+- Scopes MUST support creating child scopes.
+- Paths combine: the child's scope path is joined with the parent scope's path.
+- Environment variables merge at each level (deeper scopes override shallower ones).
+
+### Scope Destruction
+
+- Destroying a scoped backend MUST notify the parent so it can unregister the child.
+- Destroying a scoped backend MUST NOT destroy the parent.
+- Scoped backends perform no resource cleanup themselves (that is the parent's responsibility).
+
+---
+
+## MCP Integration
+
+Backends MUST provide a way to obtain an MCP (Model Context Protocol) client or transport for exposing workspace tools to AI agents.
+
+**Important:** The MCP protocol evolves independently of this spec. Before implementing or updating MCP integration, the implementer MUST consult the latest [MCP specification](https://spec.modelcontextprotocol.io/) and [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) for current transport types, client APIs, and protocol details. The behavioral requirements below describe the integration semantics; the exact MCP client/transport APIs may change across MCP SDK versions.
+
+### MCP Transport
+
+- MUST return a transport suitable for connecting to an MCP server that operates on the backend's workspace.
+- For local and memory backends: MUST spawn the `agent-backend daemon` CLI as a subprocess (stdio transport).
+- For remote backends: MUST create an HTTP transport pointing at the remote MCP server.
+- MAY accept a scope path to restrict the MCP server's workspace.
+- The returned transport MUST be tracked for automatic cleanup on destroy.
+
+### MCP Client
+
+- MUST return a connected MCP client wrapping the transport.
+- The client MUST be tracked for automatic cleanup on destroy.
+- For local backends: the CLI is spawned with appropriate flags (root directory, isolation mode, shell, local-only).
+- For remote backends: the client connects to the remote host's MCP server with authentication.
+
+### MCP Server Tools
+
+When a backend is served via MCP (through the agentbe-daemon), the daemon registers filesystem and execution tools. See the [MCP Server Tools](daemon.md#mcp-server-tools) section of the daemon spec for the full tool list and compatibility requirements.
+
+---
+
+## Connection Pooling
+
+A pool manager provides backend reuse for stateless servers (e.g., web servers handling many requests).
+
+### Key-Based Pooling
+
+- MUST maintain at most one backend instance per key.
+- If a backend for a given key exists and is connected, MUST reuse it.
+- If a backend for a given key does not exist or is not connected, MUST create a new one.
+- Requests without a key MUST create a fresh (non-pooled) backend each time.
+
+### Acquisition and Release
+
+- MUST support both explicit acquire/release and a callback pattern (execute a function with automatic release).
+- Acquiring MUST increment a usage counter; releasing MUST decrement it.
+- The callback pattern MUST release the backend even if the function throws.
+
+### Idle Cleanup
+
+- Backends with zero active usage that exceed the idle timeout MUST be eligible for cleanup.
+- Cleanup MUST call destroy on idle backends and remove them from the pool.
+- Periodic cleanup MAY be enabled via configuration.
+
+### Configuration Override
+
+- Per-request configuration overrides MUST be supported.
+- Overrides are merged with the pool's default configuration (override values take precedence).
+
+### Statistics
+
+- MUST expose pool stats: total backends, active (in-use) backends, idle backends.
+
+---
+
+## Error Handling
+
+Implementations MUST define error types that distinguish between the following failure modes:
+
+### Backend Error (base)
+
+General backend operation failure. MUST include:
+- An error code string identifying the failure type
+- A human-readable message
+- Optionally, the operation that failed
+
+### Dangerous Operation Error
+
+Thrown when a command is blocked by safety validation.
+- MUST include the command that was blocked.
+
+### Path Escape Error
+
+Thrown when a path resolves outside the workspace or scope boundary.
+- MUST include the offending path.
+
+### Not Implemented Error
+
+Thrown when an operation is not supported by the backend type (e.g., exec on memory backend).
+- MUST include the operation name and backend type.
+
+### Error Codes
+
+Implementations SHOULD use consistent error codes across backends:
+
+| Code | Meaning |
+|------|---------|
+| EMPTY_COMMAND | Empty command string passed to exec |
+| UNSAFE_COMMAND | Command failed safety check |
+| EXEC_FAILED | Command exited with non-zero status |
+| EXEC_ERROR | Command could not be spawned |
+| READ_FAILED | File read failed |
+| WRITE_FAILED | File write failed |
+| LS_FAILED | Directory listing failed |
+| PATH_ESCAPE_ATTEMPT | Path escapes workspace boundary |
+| MISSING_UTILITIES | Required system tool not found |
+| INVALID_CONFIGURATION | Configuration validation failed |
+| DANGEROUS_OPERATION | Dangerous command blocked |
+| CONNECTION_CLOSED | Connection lost (remote) |
+| KEY_NOT_FOUND | Key does not exist (memory) |
+
+---
+
+## Command Safety
+
+When dangerous command blocking is enabled, commands MUST be checked against known dangerous patterns before execution. The complete list of blocked patterns, pre-processing rules, and response format is defined in [safety.md](safety.md), which is the source of truth for command safety.
+
+The blocked patterns cover:
+
+- **Destructive operations** -- `rm -rf /`, disk overwrite, filesystem formatting, fork bombs
+- **Privilege escalation** -- `sudo`, `su`
+- **System modification** -- `chmod 777`, `chown root`
+- **Pipe-to-shell** -- `curl | sh`, `wget | bash`
+- **Direct network tools** -- `nc`, `ssh`, `scp`, `rsync`, etc.
+- **Command substitution** -- backticks, `$()`
+- **Remote code execution** -- `eval`
+- **Workspace escape** -- `cd`, `pushd`, `$HOME`, `../`, etc.
+
+See [safety.md](safety.md) for the full regex pattern list.
+
+---
+
+## Operations Logging
+
+Backends MAY support pluggable operations logging for audit and debugging.
+
+### Log Entries
+
+Each log entry MUST include:
+- Timestamp
+- Operation type (exec, read, write, mkdir, etc.)
+- Whether the operation succeeded
+- Duration
+
+Log entries SHOULD include (when applicable):
+- The command or path involved
+- User/workspace context
+- stdout/stderr for exec operations
+- Error details on failure
+
+### Logging Modes
+
+- **standard** -- Log only modifying operations (exec, write, mkdir, delete, touch).
+- **verbose** -- Log all operations including reads.
+
+---
+
+## Adapters
+
+### Vercel AI SDK Adapter
+
+Implementations MAY provide an adapter for the Vercel AI SDK that wraps a backend and exposes its MCP tools in the format expected by the AI SDK.
+
+- The adapter MUST create the appropriate MCP transport based on the backend type (stdio for local/memory, HTTP for remote).
+- The adapter MUST return a Vercel AI SDK-compatible MCP client.
+- The adapter's resources MUST be tracked by the backend for cleanup on destroy.

--- a/skills/agent-backend/daemon.md
+++ b/skills/agent-backend/daemon.md
@@ -1,0 +1,537 @@
+# agentbe-daemon
+
+> Behavioral contract for the agentbe-daemon server process -- endpoints, authentication, transports, scoping, request handling, shutdown, and Docker packaging.
+
+### Daemon-Specific Terminology
+
+**daemon** -- The long-running server process (`agentbe-daemon`) that exposes a workspace over HTTP (MCP) and WebSocket (SSH). Referred to as "the daemon" throughout this document.
+
+**transport** -- A communication channel between clients and the daemon. The daemon supports three transports: stdio (local-only), HTTP (MCP), and WebSocket (SSH).
+
+**host key** -- The SSH host key used by the ephemeral SSH server for SSH-over-WebSocket connections.
+
+**static scope** -- A scope path fixed at daemon startup via CLI argument. All requests inherit this scope.
+
+**dynamic scope** -- A scope path provided per-request via HTTP header. Allows each request to target a different sub-directory.
+
+---
+
+## Operating Modes
+
+The daemon MUST support two operating modes:
+
+### Full Mode (default)
+
+Starts an HTTP server that serves:
+- The MCP endpoint (`POST /mcp`)
+- The health endpoint (`GET /health`)
+- Optionally, the SSH-over-WebSocket endpoint (`WS /ssh`)
+- Optionally, a conventional SSH daemon (sshd)
+
+### Local-Only Mode
+
+Runs an MCP server over stdio with no network listeners. The daemon reads MCP requests from stdin and writes responses to stdout.
+
+- MUST NOT start an HTTP server.
+- MUST NOT start any SSH transport.
+- MUST create a backend from the configured root directory, optionally scoped.
+- MUST NOT enable dangerous command blocking (`preventDangerous`). Local-only mode trusts the local user; only full daemon mode requires command safety enforcement.
+- MUST connect the MCP server to a stdio transport.
+
+---
+
+## Configuration
+
+### CLI Arguments
+
+The daemon MUST be invoked via the `daemon` subcommand: `agent-backend daemon <flags>`. The entrypoint MUST strip the `daemon` subcommand before parsing flags.
+
+All flags use `--kebab-case` with a space separator for the value.
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--rootDir <path>` | string | none | **Yes** | Workspace root directory |
+| `--scopePath <path>` | string | none | No | Static scope path within rootDir |
+| `--isolation <mode>` | enum | `auto` | No | Isolation mode: `auto`, `bwrap`, `software`, `none` |
+| `--shell <shell>` | enum | `auto` | No | Shell preference: `bash`, `sh`, `auto` |
+| `--port <port>` | integer | `3001` | No | HTTP/WebSocket server port |
+| `--auth-token <token>` | string | none | No | Bearer token for authentication |
+| `--local-only` | boolean | `false` | No | Run MCP server via stdio only |
+| `--disable-ssh-ws` | boolean | `false` | No | Disable SSH-over-WebSocket endpoint |
+| `--ssh-host-key <path>` | string | none | No | Path to SSH host key file |
+| `--conventional-ssh` | boolean | `false` | No | Enable conventional SSH daemon |
+| `--ssh-port <port>` | integer | `22` | No | Conventional SSH port |
+| `--ssh-users <users>` | string | `root:agents` | No | Comma-separated `user:pass` pairs |
+| `--ssh-public-key <key>` | string | none | No | SSH public key for first user |
+| `--ssh-authorized-keys <path>` | string | none | No | Path to authorized_keys file for first user |
+
+### Validation Rules
+
+- `--rootDir` MUST be provided. The daemon MUST exit with code 1 if it is missing.
+- `--port` MUST be between 1024 and 65535 inclusive.
+- `--ssh-port` MUST be between 1 and 65535 inclusive.
+- `--isolation` MUST be one of `auto`, `bwrap`, `software`, `none`. The daemon MUST exit with code 1 on an invalid value.
+- `--shell` MUST be one of `bash`, `sh`, `auto`. The daemon MUST exit with code 1 on an invalid value.
+- `--ssh-users` MUST follow the format `user:pass[,user:pass,...]`. The daemon MUST reject entries with a missing user or password.
+- Unrecognized `--` flags MUST cause the daemon to exit with code 1.
+
+### Environment Variables (Docker)
+
+The Docker entrypoint translates the following environment variables to CLI arguments. The daemon itself does not read these directly — they are a Docker-layer convention.
+
+| Variable | Maps to | Default |
+|----------|---------|---------|
+| `WORKSPACE_ROOT` | `--rootDir` | `/var/workspace` |
+| `PORT` | `--port` | `3001` |
+| `AUTH_TOKEN` | `--auth-token` | none |
+| `SSH_HOST_KEY` | `--ssh-host-key` | none |
+| `SHELL_TYPE` | `--shell` | none (auto) |
+| `DISABLE_SSH_WS` | `--disable-ssh-ws` | `false` |
+| `CONVENTIONAL_SSH` | `--conventional-ssh` | `false` |
+| `SSH_PORT` | `--ssh-port` | `22` |
+| `SSH_USERS` | `--ssh-users` | `root:agents` |
+| `SSH_PUBLIC_KEY` | `--ssh-public-key` | none |
+| `USE_LOCAL_BUILD` | (triggers dev hot-reload) | `0` |
+
+The entrypoint MUST also check for `/keys/authorized_keys` and pass it as `--ssh-authorized-keys` if it exists.
+
+---
+
+## Endpoints
+
+### `GET /health`
+
+Health check endpoint. MUST NOT require authentication.
+
+**Response:** HTTP 200 with JSON body:
+
+```json
+{
+  "status": "ok",
+  "version": "<package version>",
+  "rootDir": "<configured rootDir>",
+  "transports": {
+    "mcp": true,
+    "ssh-ws": <boolean>,
+    "ssh": <boolean>
+  }
+}
+```
+
+- `transports.mcp` MUST always be `true`.
+- `transports.ssh-ws` MUST be `true` unless SSH-over-WebSocket is disabled.
+- `transports.ssh` MUST be `true` only when conventional SSH is enabled.
+
+### `POST /mcp`
+
+MCP (Model Context Protocol) endpoint. Handles tool calls against the workspace.
+
+**Authentication:** See [Authentication](#authentication).
+
+**Request headers:**
+- `Authorization` — Bearer token (when auth is configured).
+- `X-Root-Dir` — Optional. If present and not the string `'undefined'`, the daemon MUST verify it matches the configured `rootDir` exactly. On mismatch, the daemon MUST respond with HTTP 403:
+  ```json
+  {
+    "error": "Root directory mismatch",
+    "message": "Server is configured for <rootDir>, not <requested>"
+  }
+  ```
+- `X-Scope-Path` — Optional. Dynamic scope path for this request. See [MCP Request Handling](#mcp-request-handling).
+
+**MCP processing:** Each request MUST be handled by a fresh MCP server and transport instance. See [MCP Request Handling](#mcp-request-handling).
+
+### `WS /ssh`
+
+SSH-over-WebSocket endpoint. Upgrades HTTP connections to WebSocket for SSH transport.
+
+**Path:** `/ssh`
+
+**Authentication:** See [Authentication](#authentication). Authentication MUST occur during the WebSocket `connection` event, before SSH negotiation.
+
+On authentication failure, the daemon MUST close the WebSocket with code `4001` and reason `"Unauthorized"`.
+
+See [SSH-over-WebSocket](#ssh-over-websocket) for full transport details.
+
+---
+
+## Authentication
+
+### Bearer Token Scheme
+
+When an auth token is configured (`--auth-token`), the daemon MUST enforce authentication on the `/mcp` and `/ssh` endpoints. The `/health` endpoint MUST NOT require authentication.
+
+When no auth token is configured, all requests MUST be accepted without authentication.
+
+### MCP Endpoint Authentication
+
+The daemon MUST check the `Authorization` header for the value `Bearer <token>`. The comparison MUST be an exact string match.
+
+On failure, the daemon MUST respond with HTTP 401:
+```json
+{
+  "error": "Unauthorized",
+  "message": "Invalid or missing authentication token"
+}
+```
+
+### SSH-over-WebSocket Authentication
+
+The daemon MUST check for the token in two locations, in order:
+1. Query parameter: `/ssh?token=<token>`
+2. `Authorization` header: `Bearer <token>`
+
+If either matches, authentication succeeds. On failure, the daemon MUST close the WebSocket with code `4001` and reason `"Unauthorized"`.
+
+---
+
+## MCP Request Handling
+
+### Per-Request Backend
+
+Each `POST /mcp` request MUST be handled with its own MCP server and transport instance. The daemon MUST NOT maintain server-side session state between requests.
+
+### Scoping
+
+The daemon supports two scoping mechanisms:
+
+**Static scope** (`--scopePath`): Fixed at startup. All requests inherit this scope path.
+
+**Dynamic scope** (`X-Scope-Path` header): Per-request scope path.
+
+**Conflict handling:** If the daemon was started with a static scope AND the request also provides a dynamic scope, the daemon MUST respond with HTTP 400:
+```json
+{
+  "error": "Scope conflict",
+  "message": "Server was started with static scope '<static>', but request also specified scope '<dynamic>'. Use one or the other, not both."
+}
+```
+
+### Scope Path Validation
+
+The effective scope path (from either source) MUST be validated:
+1. Leading slashes MUST be stripped.
+2. `..` sequences MUST be rejected. If the scope path contains `..` or normalizing it changes the value, the daemon MUST respond with HTTP 400:
+   ```json
+   {
+     "error": "Invalid scope path",
+     "message": "Scope path must not contain path traversal sequences"
+   }
+   ```
+
+### Backend Construction
+
+In full daemon mode, the backend MUST be constructed with dangerous command blocking enabled (`preventDangerous: true`).
+
+If a valid scope path is present, the daemon MUST create a scoped backend from the base backend using the normalized scope path.
+
+### MCP Server Tools
+
+**Important:** The MCP protocol and its official reference servers evolve independently of this spec. Before implementing or updating MCP request handling, the implementer MUST consult the latest [MCP specification](https://spec.modelcontextprotocol.io/), the [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk), and the [official MCP Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) for current transport types, server APIs, tool schemas, and protocol details. The tool list below is a snapshot; the official filesystem server is the source of truth.
+
+The daemon MUST register the tools defined by the [official MCP Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem). Tool names, input schemas, and output formats MUST match the official filesystem MCP server exactly.
+
+At time of writing, the official filesystem MCP server provides the following tools:
+
+| Tool | Description |
+|------|-------------|
+| `read_text_file` | Read file contents as text (with optional `head`/`tail` line limits) |
+| `read_media_file` | Read an image or audio file as base64 |
+| `read_multiple_files` | Read multiple files simultaneously |
+| `write_file` | Create new file or overwrite existing |
+| `edit_file` | Selective edits using `edits: [{ oldText, newText }]` with optional `dryRun` |
+| `create_directory` | Create new directory or ensure it exists |
+| `list_directory` | List directory contents with `[FILE]`/`[DIR]` prefixes |
+| `list_directory_with_sizes` | List directory contents including file sizes, with optional `sortBy` |
+| `directory_tree` | Recursive JSON tree structure with optional `excludePatterns` |
+| `move_file` | Move or rename files and directories |
+| `search_files` | Recursively search for files matching glob patterns, with optional `excludePatterns` |
+| `get_file_info` | Get detailed file/directory metadata |
+| `list_allowed_directories` | List the workspace boundary (allowed directories) |
+
+In addition to the official filesystem tools, the daemon MUST register the following tool when the backend supports command execution:
+
+| Tool | Description |
+|------|-------------|
+| `exec` | Execute a shell command. Parameters: `command` (string, required), `env` (object, optional). |
+
+---
+
+## SSH-over-WebSocket
+
+### WebSocket Upgrade
+
+The daemon MUST listen for WebSocket upgrade requests at the `/ssh` path.
+
+If `--disable-ssh-ws` is set, the daemon MUST NOT create the WebSocket server.
+
+### Duplex Stream Bridging
+
+The daemon MUST create a duplex stream from each WebSocket connection to bridge with the SSH server:
+
+- Writes to the duplex MUST send data via `ws.send()`. If the WebSocket is not in the OPEN state, writes MUST fail with an error.
+- Incoming WebSocket messages MUST be pushed into the readable side of the duplex as Buffers.
+- WebSocket `close` MUST push EOF (null) to the readable side.
+- WebSocket `error` MUST destroy the duplex stream.
+- Calling `final()` on the duplex MUST close the WebSocket with code 1000.
+- Calling `destroy()` on the duplex MUST close the WebSocket with code 1011.
+
+The duplex stream MUST be injected into an SSH server instance for protocol handling.
+
+### SSH Server Per Connection
+
+Each WebSocket connection MUST get its own ephemeral SSH server instance. When the WebSocket closes, the SSH server for that connection is torn down.
+
+### SSH Authentication Passthrough
+
+Once WebSocket-level authentication succeeds, the SSH server MUST accept all SSH authentication methods (password, publickey, none). The rationale is that transport-level token authentication has already been performed.
+
+### Host Key Management
+
+The daemon MUST support loading an SSH host key from a file (`--ssh-host-key`) or auto-generating one.
+
+- **Default path:** `/var/lib/agentbe/ssh_host_ed25519_key`
+- **Key algorithm:** RSA (2048-bit). The key MUST be generated via `generateKeyPairSync('rsa', { modulusLength: 2048 })` (or equivalent) with PKCS#1 PEM encoding.
+- If the file at the configured (or default) path exists, the daemon MUST read and use it.
+- If the file does not exist, the daemon MUST generate a new RSA key pair and attempt to save it for reuse.
+- If the directory cannot be created or the file cannot be written, the daemon MUST use the generated key ephemerally (in-memory only, not persisted). This MUST NOT be a fatal error.
+
+### Session Types
+
+The SSH server MUST handle the following session types:
+
+#### PTY Requests
+
+The daemon MUST accept PTY requests and store the terminal information (term type, columns, rows) for use by subsequent shell or exec requests.
+
+#### Shell Sessions
+
+When a shell session is requested:
+- The daemon SHOULD attempt to use a PTY-capable spawner (e.g., `node-pty`) if available, for proper terminal emulation.
+- If PTY support is unavailable, the daemon MUST fall back to executing the resolved shell as a command.
+- Default terminal type: `xterm-256color`. Default dimensions: 80 columns, 24 rows.
+
+#### Exec Sessions
+
+When a command exec is requested:
+- The daemon MUST spawn the command via the resolved shell with `-c` flag.
+- Working directory MUST be set to the workspace root (or scoped root).
+- Environment MUST include `HOME`, `PWD` (set to the working directory), and `TERM=xterm-256color`.
+- The exit code MUST be sent via the SSH channel's exit method.
+- On spawn failure, the daemon MUST write the error to stderr on the channel and exit with code 1.
+
+#### Window Change
+
+The daemon MUST handle `window-change` session events. These events indicate a PTY resize. The daemon MUST accept the event (call `accept()` if provided). Implementations SHOULD propagate the new dimensions to the active PTY process if one is tracked.
+
+#### SFTP Sessions
+
+The daemon MUST support SFTP sessions. See [SFTP Path Jailing](#sftp-path-jailing).
+
+### Shell Resolution
+
+The daemon MUST resolve the shell to use:
+- `'bash'` → `/bin/bash`
+- `'sh'` → `/bin/sh`
+- `'auto'` or unset → prefer `/bin/bash` if it exists, fall back to `/bin/sh`
+
+---
+
+## SFTP Path Jailing
+
+All SFTP operations MUST be confined to the workspace root directory.
+
+### Path Resolution
+
+For every SFTP operation, the daemon MUST resolve paths as follows:
+1. Normalize the workspace root via an absolute path resolve.
+2. If the requested path already starts with the normalized root (followed by `/` or is equal), use it directly.
+3. Otherwise, strip leading slashes and resolve relative to the workspace root.
+4. After resolution, verify the resolved path starts with the normalized root (followed by `/` or is equal). If not, the operation MUST fail with a path escape error.
+
+### Supported SFTP Operations
+
+The daemon MUST implement the following SFTP operations:
+
+| Operation | Notes |
+|-----------|-------|
+| OPEN | Auto-create parent directories for write operations. Default file mode: `0o644`. SFTP open flags MUST be translated to OS-level flags (e.g., `SSH2_FXF_READ` → `O_RDONLY`, `SSH2_FXF_WRITE` → `O_WRONLY`, `SSH2_FXF_CREAT` → `O_CREAT`, `SSH2_FXF_TRUNC` → `O_TRUNC`, `SSH2_FXF_EXCL` → `O_EXCL`, `SSH2_FXF_APPEND` → `O_APPEND`). Flags MUST be combined bitwise. |
+| READ | Return `EOF` status when zero bytes are read. |
+| WRITE | Write at specified offset. |
+| CLOSE | Close file handle and free the handle ID. |
+| FSTAT | Stat an open file handle. |
+| OPENDIR | Read directory entries into memory. |
+| READDIR | Return entries in batches. Return `EOF` status when exhausted. |
+| STAT | Stat a path (follows symlinks). |
+| LSTAT | Stat a path (does not follow symlinks). |
+| REALPATH | Return the resolved path relative to the workspace root, presented to the client as an absolute path from `/`. |
+| MKDIR | Default mode: `0o755`. |
+| RMDIR | Remove an empty directory. |
+| REMOVE | Delete a file. |
+| RENAME | Auto-create parent directory of destination. Both paths MUST be validated within the workspace root. |
+| SETSTAT | Support chmod. Chown and utimes MAY silently ignore errors. |
+| FSETSTAT | Same as SETSTAT but on an open file handle. |
+
+### Error Mapping
+
+SFTP errors MUST be mapped from OS error codes:
+- `ENOENT` → `NO_SUCH_FILE`
+- `EACCES` → `PERMISSION_DENIED`
+- All other errors → `FAILURE`
+
+---
+
+## Conventional SSH (Opt-In)
+
+The daemon MAY support running a conventional SSH daemon (sshd) alongside the HTTP server.
+
+### Platform Requirements
+
+- `--conventional-ssh` MUST require Linux (`process.platform === 'linux'`). The daemon MUST exit with code 1 on other platforms.
+- `--conventional-ssh` SHOULD require root privileges. The daemon SHOULD print a warning if not running as root.
+- The daemon MUST verify `/usr/sbin/sshd` exists. If missing, the daemon MUST exit with code 1.
+
+### User Setup
+
+When conventional SSH is enabled, the daemon MUST:
+1. Create Linux users from the `--ssh-users` list using `useradd -m -s /bin/bash`.
+2. Set passwords via `chpasswd`.
+3. Create `.ssh` directories with mode `700` and `authorized_keys` files with mode `600`.
+4. Apply `--ssh-public-key` and `--ssh-authorized-keys` to the first user only.
+5. Enable password authentication via an sshd configuration drop-in file.
+
+### sshd Process
+
+The daemon MUST spawn sshd with `-D` (foreground) and `-e` (log to stderr) flags on the configured port.
+
+If sshd exits unexpectedly, the daemon MUST close the HTTP server and exit with code 1.
+
+---
+
+## Graceful Shutdown
+
+The daemon MUST handle `SIGTERM` and `SIGINT` for graceful shutdown.
+
+### Close Ordering
+
+On receiving a shutdown signal, the daemon MUST close resources in the following order:
+
+1. **SSH-over-WebSocket server** — Close all active WebSocket clients with code 1000 and reason `"Server shutting down"`, then close the WebSocket server.
+2. **HTTP server** — Stop accepting new connections and close the HTTP server.
+3. **Conventional sshd** (if running) — Send `SIGTERM` to the sshd process and wait for it to exit.
+4. **Exit** — Exit the process with code 0.
+
+---
+
+## Docker Image
+
+### Base Image
+
+The Docker image MUST use `ubuntu:22.04` as the base image.
+
+### Build Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `INCLUDE_SSHD` | `true` | Include openssh-server |
+| `AGENTBE_VERSION` | `local` | Package version or `local` for local build |
+
+### Installed Tooling
+
+The image MUST include:
+- `sudo`, `curl`, `wget`, `tree`, `ripgrep`, `git`
+- `python3`, `python3-pip`
+- Node.js 20 (via nodesource)
+- `pnpm`, `tsx` (global npm packages)
+- `agent-backend` (from npm or local build)
+- `openssh-server` (when `INCLUDE_SSHD=true`)
+
+### Build-Time SSH Configuration
+
+When `INCLUDE_SSHD=true`, the image MUST configure sshd at build time:
+
+1. Create `/var/run/sshd` and `/run/sshd` directories.
+2. Generate SSH host keys (`ssh-keygen -A`).
+3. Modify `/etc/ssh/sshd_config`:
+   - `PermitRootLogin yes`
+   - `PasswordAuthentication yes`
+   - `PubkeyAuthentication yes`
+   - `ListenAddress 0.0.0.0`
+4. Create an sshd config drop-in file (`/etc/ssh/sshd_config.d/agentbe.conf`) with:
+   - `PasswordAuthentication yes`
+   - `PermitRootLogin yes`
+   - `ChallengeResponseAuthentication yes`
+   - `MaxSessions 64`
+   - `MaxStartups 10:30:100`
+   - `ClientAliveInterval 60`
+   - `ClientAliveCountMax 3`
+5. Configure PAM: change `pam_loginuid.so` from `required` to `optional` in `/etc/pam.d/sshd`.
+6. Create `/root/.ssh` (mode `700`) with an empty `authorized_keys` file (mode `600`).
+7. Set the default root password (`root:agents`) via `chpasswd`.
+
+### Workspace Directory
+
+The image MUST create `/var/workspace` with mode `755`, owned by `root:root`.
+
+### Exposed Ports
+
+- `3001` — MCP + SSH-over-WebSocket
+- `22` — Conventional SSH
+
+### Health Check
+
+The image MUST define a health check:
+- Command: `curl -f http://localhost:${PORT:-3001}/health`
+- Interval: 30 seconds
+- Timeout: 10 seconds
+- Start period: 5 seconds
+- Retries: 3
+
+### Entrypoint Behavior
+
+The entrypoint script (`/docker-entrypoint.sh`) MUST:
+
+1. If invoked as `agent-backend daemon`:
+   a. Strip the `agent-backend daemon` prefix (`shift 2`) so remaining args can be passed through.
+   b. Create the `WORKSPACE_ROOT` directory (default `/var/workspace`) with mode `755`.
+   c. Run all executable `*.sh` scripts in `/docker-entrypoint.d/`, sorted by version sort. Non-executable `.sh` files and non-`.sh` files SHOULD be logged as ignored.
+   d. Translate environment variables to CLI arguments. Arguments MUST be stored in a bash array (not a string) to safely handle values containing spaces.
+   e. Change to `WORKSPACE_ROOT`.
+   f. Execute the daemon via `exec` so the daemon process replaces the shell and becomes PID 1 in the container. This is critical for proper signal handling (SIGTERM, SIGINT). Any remaining positional args (`"$@"`) MUST be appended to allow Docker CMD overrides to pass additional flags.
+2. For any other command, execute it directly via `exec "$@"`.
+
+The entrypoint MUST use `set -e` (fail on any error).
+
+### Extension Points
+
+The image MUST support three extension mechanisms:
+
+1. **`FROM` + `RUN`** — Extend the image with additional packages via a downstream Dockerfile.
+2. **`/docker-entrypoint.d/*.sh`** — Drop-in init scripts executed at container startup before the daemon starts.
+3. **`CMD` override** — Replace the default command entirely.
+
+### Dev Hot-Reload
+
+When `USE_LOCAL_BUILD=1` and the local source directory exists at `/app/agent-backend/src`, the entrypoint MUST use `tsx --watch` to run the daemon from source with automatic restart on file changes.
+
+---
+
+## Security Considerations
+
+### Path Jailing
+
+All file operations — whether via MCP tools, SFTP, or shell execution — MUST be confined to the workspace root directory. Path traversal attempts (`..`) MUST be detected and rejected at every layer (MCP scope validation, SFTP path resolution, backend path resolution).
+
+### Command Isolation
+
+In full daemon mode, the backend MUST be configured with dangerous command blocking enabled. The daemon delegates command safety enforcement to the backend layer (see [Command Safety](safety.md) for the full list of blocked patterns).
+
+### Authentication Token Recommendations
+
+- Deployments exposed to the network SHOULD configure an auth token.
+- Auth tokens SHOULD be generated with sufficient entropy (e.g., 256-bit random).
+- Tokens are compared via exact string match. Implementations SHOULD use constant-time comparison to prevent timing attacks.
+
+### SSH Host Key Stability
+
+For production deployments, operators SHOULD provide a persistent host key via `--ssh-host-key` to prevent host key mismatch warnings on client reconnection. Auto-generated keys are ephemeral when the file cannot be persisted, meaning clients will see a different host key each time the daemon restarts.

--- a/skills/agent-backend/safety.md
+++ b/skills/agent-backend/safety.md
@@ -1,0 +1,96 @@
+# Command Safety
+
+> Behavioral contract for command safety validation -- pre-processing rules, dangerous command patterns, workspace escape patterns, and response format.
+
+Both the [daemon spec](daemon.md) and [client spec](clients.md) reference this document for the complete list of blocked patterns. When dangerous command blocking is enabled, commands MUST be checked against the patterns defined here before execution.
+
+---
+
+## Pre-processing
+
+- Commands MUST be normalized to lowercase before pattern matching.
+- Heredoc content MUST be stripped before safety validation to prevent false positives (heredocs contain literal data, not executable commands).
+- Implementations MAY define allowed patterns that override specific blocked patterns. The default allowlist MUST include `gcloud rsync` (a gcloud subcommand, not the `rsync` binary).
+- Allowed patterns MUST be checked before dangerous patterns; if a command matches an allowed pattern, it is not dangerous.
+
+---
+
+## Dangerous Command Patterns
+
+The following regex patterns MUST be blocked. Each pattern uses `\b` for word boundaries where appropriate.
+
+**Destructive operations:**
+- `\brm\b.*-rf?\b.*[/~*]` and `\brm\b.*[/~*].*-rf?\b` -- system-wide destructive rm
+- `\bdd\b.*\bof=\/dev\/` -- disk wiping with dd
+
+**Privilege escalation:**
+- `\bsudo\b`, `\bsu\b`
+
+**System modification:**
+- `\bchmod\b.*777`, `\bchown\b.*root`
+
+**Pipe-to-shell (download-and-execute):**
+- `curl\b.*\|\s*(sh|bash|zsh|fish)\b`
+- `wget\b.*\|\s*(sh|bash|zsh|fish)\b`
+- `\|\s*(sh|bash|zsh|fish)\s*$`
+
+**Direct network tools:**
+- `\bnc\b`, `\bncat\b`, `\bnetcat\b`, `\btelnet\b`, `\bftp\b`, `\bssh\b`, `\bscp\b`, `\brsync\b`
+
+**Process and system control:**
+- `\bkill\s+-9`, `\bkillall\b`, `\bpkill\b`
+- `\bshutdown\b`, `\breboot\b`, `\bhalt\b`, `\binit\s+[06]\b`
+
+**Filesystem manipulation:**
+- `\bmount\b`, `\bumount\b`, `\bfdisk\b`, `\bmkfs\b`, `\bfsck\b`
+
+**Command substitution:**
+- `` `[^`]+` `` -- backtick substitution
+- `\$\([^)]+\)` -- `$()` substitution
+
+**Remote code execution:**
+- `\beval\b`
+
+**Resource exhaustion:**
+- `:\(\)` -- fork bomb pattern
+- `fork\(\)`
+- `\bwhile\s+true\b`
+- `\byes\b.*>\s*\/dev\/null`
+
+**Network tampering:**
+- `\biptables\b`
+- `\bifconfig\b.*\bdown\b`
+
+**System file modification:**
+- `>>?\s*\/etc\/`, `>\s*\/etc\/`
+- `\bcat\b.*>\s*\/etc\/`, `\becho\b.*>\s*\/etc\/`
+
+**Obfuscation:**
+- `[a-z]""[a-z]` -- string obfuscation (e.g., `r""m`)
+
+**Path traversal in sensitive operations:**
+- `\b(cp|mv|ln)\b.*\.\.\/`
+
+**Symbolic link creation:**
+- `\bln\s+-s`
+
+---
+
+## Workspace Escape Patterns
+
+Implementations SHOULD also block commands that attempt to escape the workspace. The following patterns MUST be checked (after heredoc stripping):
+
+- `\bcd\b`, `\bpushd\b`, `\bpopd\b` -- directory change commands
+- `export\s+PATH=`, `export\s+HOME=`, `export\s+PWD=` -- environment manipulation
+- `~\/` -- home directory reference
+- `\$HOME`, `\$\{HOME\}` -- HOME variable references
+- `\.\.[/\\]` -- parent directory traversal
+- `` `[^`]+` ``, `\$\([^)]+\)` -- command substitution (may be used to escape)
+
+---
+
+## Safety Check Response
+
+When a command is blocked, the response MUST include:
+- A `safe: false` status.
+- A `reason` string. Implementations SHOULD provide specific guidance for common cases (e.g., for pipe-to-shell: "Download to a file first, inspect it, then execute if safe").


### PR DESCRIPTION
Adds agent-backend v0.9.5 to the OpenSDD registry.

Client library and server daemon providing a unified API for agent-filesystem interaction within local or remote sandboxed workspaces